### PR TITLE
Removed Record not deleted on the client under load stress

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,66 +39,66 @@ This might be taken in consideration when implementing a load balancing strategy
 
 Create a publication on the backend. the publication is set to listen to data changes
  ex:
+  
+     sync.publish('magazines.sync',function(tenantId,userId,params){
+       return magazineService.fetchForUser(userId,params.type)
+       },MAGAZINE_DATA);
+     }
  
- '''
-  sync.publish('magazines.sync',function(tenantId,userId,params){
-    return magazineService.fetchForUser(userId,params.type)
- },MAGAZINE_DATA);
- }
- '''
+
 
  Subscribe to this publication on the client (In this example, it is a subscription to an array)
  ex:
 
-'''
- var sds = $sync.subscribe(
+    var sds = $sync.subscribe(
             'magazines',
             scope).setParameters({ type: 'fiction'});
-var mySyncList = sds.getData();
- '''
+    var mySyncList = sds.getData();
+
 
  When your api update, create or remove data, notify the data changes on the backend. You might provide params that must be in the subscription to react. 
  ex:
 
-'''
- var zerv = require("zerv-core");
- function createMagazine(magazine) {
-    magazine.revision = 0;
-    return saveInDb(magazine).then(function (magazine) {
-        zerv.notifyCreation('MAGAZINE_DATA', magazine);
-        return magazine
-    });
- }
 
- function updateMagazine(magazine) {
-    magazine.revision++;
-    return saveInDb(magazine).then(function (magazine) {
-        zerv.notifyChanges('MAGAZINE_DATA', magazine);
+     var zerv = require("zerv-core");
+     function createMagazine(magazine) {
+        magazine.revision = 0;
+        return saveInDb(magazine).then(function (magazine) {
+            zerv.notifyCreation('MAGAZINE_DATA', magazine);
+            return magazine
+        });
+     }
+
+     function updateMagazine(magazine) {
+        magazine.revision++;
+        return saveInDb(magazine).then(function (magazine) {
+            zerv.notifyChanges('MAGAZINE_DATA', magazine);
         return magazine
-    });
- }
+        });
+     }
  
- function removeMagazine(magazine) {
-    magazine.revision++;
-    return removeFromDb(magazine).then(function (rep) {
-        zerv.notifyRemoval('MAGAZINE_DATA', magazine);
-        return rep;
-    });
- }
-'''
+     function removeMagazine(magazine) {
+        magazine.revision++;
+        return removeFromDb(magazine).then(function (rep) {
+            zerv.notifyRemoval('MAGAZINE_DATA', magazine);
+            return rep;
+        });
+     }
+
 
  ### Example
-'''
+
 A publication might have options
  ex:
-  sync.publish('magazines.sync',function(tenantId,userId,params){
-    return magazineService.fetchForUser(userId,params.type)
- },MAGAZINE_DATA,
- {
-     always:true
- });
- }
-'''
+
+     sync.publish('magazines.sync',function(tenantId,userId,params){
+        return magazineService.fetchForUser(userId,params.type)
+     },MAGAZINE_DATA,
+     {
+         always:true
+     });
+     }
+
 when always is true, each time there is a notification on MAGAZINE_DATA, the fetch will run and all records will get pushed to the client instead of only the notified one.
 
 ### Publication options

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ When the subscription is established, the backend subscription will fetch data f
 When data is updated in the backend, a notification must be implemented to emit the data/object change.
 Publications react to those notifications. They will directly push the changes to their subscribers if determined to be related.
 
-The idea is to decrease the number of accesses to the db:
+The objective is to decrease the number of accesses to the db:
 
 - In most cases, the publication only needs to access the persistence layer at initialization.
 - If the connection to the subscribers is lost for a short period of time, the publication caches next changes and give enough time for the client to reconnect.
@@ -103,11 +103,12 @@ when always is true, each time there is a notification on MAGAZINE_DATA, the fet
 
 ### Publication options
 
-always: Push all records to the client for each notification
+always: Push all records to the client for each notification. By default, only notified object might be pushed to the client.
 
 once: Push all records to the client once then do not push anything else even when notified
 
 init: Provide a function for third parameters.  The params from the subscriptions might required additional parameters not known to the subscriber but necessary to the publication
+
       function init(tenantId, user, additionalParams) {
           additionalParams.tenantId = tenantId;
       }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# socketio-sync
+# zerv-sync
 
 
 
@@ -9,11 +9,11 @@ This node module handles the data synchronization on the server side over socket
 
 ### pre-requisite
 
-socketio-auth middleware
-First, set up your node server to use express with socketio-auth.
+zerv-core middleware
+First, set up your node server to use express with the zerv-core module.
 
-Angular-sync client
-It requires the client to use the angular-sync bower package to establish the syncing process.
+zerv-ng-sync client
+It requires the client to use the zerv-ng-sync bower package to establish the syncing process.
 
 
 ### Principle
@@ -47,8 +47,7 @@ Create a publication on the backend. the publication is set to listen to data ch
  Subscribe to this publication on the client (In this example, it is a subscription to an array)
  ex:
 
- var sync = require("socketio-sync")
- var sds = sync.subscribe(
+ var sds = $sync.subscribe(
             'magazines',
             scope).setParameters({ type: 'fiction'});
 var mySyncList = sds.getData();
@@ -56,11 +55,11 @@ var mySyncList = sds.getData();
  When your api update, create or remove data, notify the data changes on the backend. You might provide params that must be in the subscription to react. 
  ex:
 
- var sync = require("socketio-sync")
+ var zerv = require("zerv-core");
  function createMagazine(magazine) {
     magazine.revision = 0;
     return saveInDb(magazine).then(function (magazine) {
-        sync.notifyChanges('MAGAZINE_DATA', magazine);
+        zerv.notifyCreation('MAGAZINE_DATA', magazine);
         return magazine
     });
  }
@@ -68,7 +67,7 @@ var mySyncList = sds.getData();
  function updateMagazine(magazine) {
     magazine.revision++;
     return saveInDb(magazine).then(function (magazine) {
-        sync.notifyChanges('MAGAZINE_DATA', magazine);
+        zerv.notifyChanges('MAGAZINE_DATA', magazine);
         return magazine
     });
  }
@@ -76,7 +75,7 @@ var mySyncList = sds.getData();
  function removeMagazine(magazine) {
     magazine.revision++;
     return removeFromDb(magazine).then(function (rep) {
-        sync.notifyRemoval('MAGAZINE_DATA', magazine);
+        zerv.notifyRemoval('MAGAZINE_DATA', magazine);
         return rep;
     });
  }

--- a/README.md
+++ b/README.md
@@ -39,22 +39,28 @@ This might be taken in consideration when implementing a load balancing strategy
 
 Create a publication on the backend. the publication is set to listen to data changes
  ex:
+ 
+ '''
   sync.publish('magazines.sync',function(tenantId,userId,params){
     return magazineService.fetchForUser(userId,params.type)
- },[MAGAZINE_DATA]);
+ },MAGAZINE_DATA);
  }
- 
+ '''
+
  Subscribe to this publication on the client (In this example, it is a subscription to an array)
  ex:
 
+'''
  var sds = $sync.subscribe(
             'magazines',
             scope).setParameters({ type: 'fiction'});
 var mySyncList = sds.getData();
- 
+ '''
+
  When your api update, create or remove data, notify the data changes on the backend. You might provide params that must be in the subscription to react. 
  ex:
 
+'''
  var zerv = require("zerv-core");
  function createMagazine(magazine) {
     magazine.revision = 0;
@@ -79,6 +85,32 @@ var mySyncList = sds.getData();
         return rep;
     });
  }
+'''
+
+ ### Example
+'''
+A publication might have options
+ ex:
+  sync.publish('magazines.sync',function(tenantId,userId,params){
+    return magazineService.fetchForUser(userId,params.type)
+ },MAGAZINE_DATA,
+ {
+     always:true
+ });
+ }
+'''
+when always is true, each time there is a notification on MAGAZINE_DATA, the fetch will run and all records will get pushed to the client instead of only the notified one.
+
+### Publication options
+
+always: Push all records to the client for each notification
+
+once: Push all records to the client once then do not push anything else even when notified
+
+init: Provide a function for third parameters.  The params from the subscriptions might required additional parameters not known to the subscriber but necessary to the publication
+      function init(tenantId, user, additionalParams) {
+          additionalParams.tenantId = tenantId;
+      }
 
 ### Other
 

--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -226,7 +226,9 @@ function clear() {
  *              }
  *                 
  * @param <object> options: object with followings:
- *        init: function to provided additional params that will be used to check if a subscription listens to the notified data(new, updated or removed data),
+ *          - <function> init: function to provided additional params that will be used to check if a subscription listens to the notified data(new, updated or removed data),
+ *          - <boolean> once: when true, the publication will push the data once only, if there is notification, data will not be pushed but if the network fails data will be pushed again
+ *          - <boolean> always: when true, the publication will push all data when it is notified instead of just the record being notified
 */
 function publish(name, fetchFn, dataNotification, options) {
     var dataNotifications;
@@ -256,6 +258,7 @@ function publish(name, fetchFn, dataNotification, options) {
     if (options) {
         publication.init = options.init; // option to provide third params
         publication.once = options.once; // will publish only once..then unsubscribe the client
+        publication.always = options.always; // will push all data each time there is a notification
     }
     publications[name] = publication;
     return sync;
@@ -264,6 +267,8 @@ function publish(name, fetchFn, dataNotification, options) {
 
 /**
  * Register a callback on data changes
+ *
+ * Note: the call back would be run in all the nodes of a clusters. So it might not be a good option if the callback is supposed to only be run once in the system.
  *
  * @param <string> dataNotification
  * @param <function> callback which returns a promise;
@@ -290,94 +295,94 @@ function onDataChanges(dataNotification, callback) {
  */
 function notifyChanges(dataNotification, object, options) {
     logger.warn('notifyChanges() is deprecated. Use notifyCreate or notifyUpdate instead');
-    var record = serialize(object);
-    notifyRecordActivity(null, dataNotification, record, options)
+    notifyUpdate(null, dataNotification, object, options)
 }
 
 /**
- * Notify a record removal. 
+ * Notify a record removal.
+ *
  * @deprecated since it does not pass the tenantId. use notifyDelete
  * 
  */
-function notifyRemoval(dataNotification, object) {
+function notifyRemoval(dataNotification, object, options) {
     logger.warn('notifyRemoval() is deprecated. Use notifyDelete instead.');
-    var record = serialize(object);
-    record.remove = new Date();
-    notifyChanges(dataNotification, record);
+    notifyDelete(null, dataNotification, object, options)
 }
 
 /**
  * Notify a record removal. 
- * Before notifying, make sure the record revision was increased. 
+ * Before notifying, make sure the record revision was increased.
+ *
+ * @param <uid> tenantId,
+ * @param <string> dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
+ * @param <object> record: Object/Record to notify to listening publication (must at least have an id and revision number)
  * 
- * @param dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
- * @param record: Object/Record to notify to listening publication (must at least have an id and revision number)
  * 
  */
 function notifyDelete(tenantId, dataNotification, object, options) {
-    var record = serialize(object);
-    record.remove = new Date();
-    notifyRecordActivity(tenantId, dataNotification, record, options);
+    notifyRecordActivity(tenantId, dataNotification, 'REMOVAL', object, options);
 }
 
 /**
  * Notify a record update. 
  * Before notifying, make sure the record revision was increased
  * 
- * @param dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
- * @param record: Object/record to notify to listening publication
- *  
+ * @param <uid> tenantId,
+ * @param <string> dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
+ * @param <object> record: Object/Record to notify to listening publication (must at least have an id and revision number)
+  *  
  * Notes:
  * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
  */
 function notifyUpdate(tenantId, dataNotification, object, options) {
-    var record = serialize(object);
-    record.update = true;
-    notifyRecordActivity(tenantId, dataNotification, record, options);
+    notifyRecordActivity(tenantId, dataNotification, 'UPDATE', object, options);
 }
 
 /**
  * Notify a record creation. 
  * Before notifying, make sure the record revision was increased
  * 
- * @param dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
- * @param record: Object/record to notify to listening publication
- *  
+ * @param <uid> tenantId,
+ * @param <string> dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
+ * @param <object> record: Object/Record to notify to listening publication (must at least have an id and revision number)
+  *  
  * Notes:
  * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
  */
 function notifyCreation(tenantId, dataNotification, object, options) {
-    var record = serialize(object);
-    record.update = false;
-    notifyRecordActivity(tenantId, dataNotification, record, options);
+    notifyRecordActivity(tenantId, dataNotification, 'ADD', object, options);
 }
 
 
 ////////////////// HELPERS //////////////////////
-function serialize(object) {
-    // When the subscription params are checked against the object notified to sync, the object must be serialized so it contains ids, no object references. Subscription params are id based.
-    return JSON.parse(JSON.stringify(object));
-}
 
-function notifyRecordActivity(tenantId, dataNotification, record, options) {
+function notifyRecordActivity(tenantId, dataNotification, notificationType, object, options) {
     options = options || {}
-    notifyCluster(tenantId, dataNotification, record, options);
 
-    notifyChangeListeners(tenantId, dataNotification, record, options);
+    notifyChangeListeners(tenantId, dataNotification, notificationType, object, options);
+
+    notifyCluster(tenantId, dataNotification, notificationType, object, options);
 
     findPublicationsListeningToDataNotification(dataNotification)
         .forEach(function (publication) {
 
-            publication.dataNotifications[dataNotification](record, record.remove ? 'REMOVAL' : record.update ? 'UPDATE' : 'ADD', publication.params).then(function (record) {
+            publication.dataNotifications[dataNotification](object, notificationType, publication.params).then(function (record) {
 
                 findSubscriptionsUsingPublication(publication.name)
                     .forEach(function (subscription) {
-                        // make sure that the subscription is matching the notification params..so that we don't call the db for nothing!!
-                        if (options.forceNotify === true || subscription.checkIfMatch(record)) {
-                            //subscription.emitChanges();
-                            // but In order to prevent fetching, would need to replace by
-                            subscription.emitChange(record);
-                            // 
+                        try {
+                            // make sure that the subscription is matching the notification params..so that we don't call the db for nothing!!
+                            if (options.forceNotify === true || subscription.checkIfMatch(object)) {
+                                // if alwaysFetch, all the records will be retrieved and pushed each time there is a notification (Db performance impact)
+                                if (publication.always) {
+                                    subscription.emitAllRecords();
+                                } else {
+                                    subscription.emitChange(object, notificationType);
+                                }
+                            }
+                        } catch (err) {
+                            // unrecoverable error... check record validity.
+                            logger.error(err, err.stack);
                         }
                     });
             });
@@ -391,13 +396,13 @@ function notifyRecordActivity(tenantId, dataNotification, record, options) {
  *  @param <string> tenantId
  *  @param <string 
  */
-function notifyChangeListeners(tenantId, dataNotification, record, options) {
+function notifyChangeListeners(tenantId, dataNotification, notificationType, record, options) {
     var listeners = changeListeners[dataNotification];
     if (listeners) {
         listeners.forEach(function (callback) {
             // this make sure we show most silent error. If callback deals with promises it should return a promise
             try {
-                var r = callback(tenantId, record, options);
+                var r = callback(tenantId, record, notificationType, options);
                 if (r && r.then) {
                     r.catch(function (err) {
                         logger.error('Error in callback of the notification listener %b.', dataNotification, err.stack || err);
@@ -546,7 +551,10 @@ function Subscription(user, subscriptionId, publication, params) {
         return; // does not return a promise here on purpose (non blocking)
     }
 
-    function emitChange(record) {
+    function emitChange(record, notificationType) {
+        if (notificationType === 'REMOVAL') {
+            record.remove = new Date();
+        }
         addToQueue(record);
         // if there is more than one record currently in the queue...it means client has not gotten all the data yet. Could be due a slow or lost of connection. but...so let's wait it finishes and avoid emitting again.
         // the emitCache function will catch up and try to empty the queue anyway.
@@ -613,7 +621,10 @@ function Subscription(user, subscriptionId, publication, params) {
     }
 
 
-    function checkIfMatch(dataParams) {
+    function checkIfMatch(object) {
+
+        // When the subscription params are checked against the object notified to sync, the object must be serialized so it contains ids, no object references. Subscription params are id based.
+        var dataParams = JSON.parse(JSON.stringify(object));
 
         // seid
         // sds.subscribe('forecast.sync',{opportunityId:id,type:'monthly'});
@@ -632,7 +643,6 @@ function Subscription(user, subscriptionId, publication, params) {
         // {init:function(tenant,user, params) {
         //      params.type = null;        
         //}}
-
 
         // if additional params has a null param, the params should not be used as identityParams
         // ex a subscription might pass some params not useful such as startDate, endDate, type... which are not useful for notification.

--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -206,7 +206,7 @@ function setLogLevel(value) {
  * This is used for test purposes.
  */
 function clear() {
-    _.values(activeSubscriptions).forEach(function (subscription) {
+    _.values(activeSubscriptions).forEach(function(subscription) {
         subscription.release();
     })
 }
@@ -229,7 +229,7 @@ function clear() {
  *          - <function> init: function to provided additional params that will be used to check if a subscription listens to the notified data(new, updated or removed data),
  *          - <boolean> once: when true, the publication will push the data once only, if there is notification, data will not be pushed but if the network fails data will be pushed again
  *          - <boolean> always: when true, the publication will push all data when it is notified instead of just the record being notified
-*/
+ */
 function publish(name, fetchFn, dataNotification, options) {
     var dataNotifications;
 
@@ -240,7 +240,7 @@ function publish(name, fetchFn, dataNotification, options) {
         }
     } else if (typeof dataNotification === 'string') {
         dataNotifications = {};
-        dataNotifications[dataNotification] = function (record) {
+        dataNotifications[dataNotification] = function(record) {
             return Promise.resolve(record);
         }
     } else {
@@ -330,7 +330,7 @@ function notifyDelete(tenantId, dataNotification, object, options) {
  * @param <uid> tenantId,
  * @param <string> dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
  * @param <object> record: Object/Record to notify to listening publication (must at least have an id and revision number)
-  *  
+ *  
  * Notes:
  * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
  */
@@ -345,7 +345,7 @@ function notifyUpdate(tenantId, dataNotification, object, options) {
  * @param <uid> tenantId,
  * @param <string> dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
  * @param <object> record: Object/Record to notify to listening publication (must at least have an id and revision number)
-  *  
+ *  
  * Notes:
  * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
  */
@@ -364,12 +364,12 @@ function notifyRecordActivity(tenantId, dataNotification, notificationType, obje
     notifyCluster(tenantId, dataNotification, notificationType, object, options);
 
     findPublicationsListeningToDataNotification(dataNotification)
-        .forEach(function (publication) {
+        .forEach(function(publication) {
 
-            publication.dataNotifications[dataNotification](object, notificationType, publication.params).then(function (record) {
+            publication.dataNotifications[dataNotification](object, notificationType, publication.params).then(function(record) {
 
                 findSubscriptionsUsingPublication(publication.name)
-                    .forEach(function (subscription) {
+                    .forEach(function(subscription) {
                         try {
                             // make sure that the subscription is matching the notification params..so that we don't call the db for nothing!!
                             if (options.forceNotify === true || subscription.checkIfMatch(object)) {
@@ -399,12 +399,12 @@ function notifyRecordActivity(tenantId, dataNotification, notificationType, obje
 function notifyChangeListeners(tenantId, dataNotification, notificationType, record, options) {
     var listeners = changeListeners[dataNotification];
     if (listeners) {
-        listeners.forEach(function (callback) {
+        listeners.forEach(function(callback) {
             // this make sure we show most silent error. If callback deals with promises it should return a promise
             try {
                 var r = callback(tenantId, record, notificationType, options);
                 if (r && r.then) {
-                    r.catch(function (err) {
+                    r.catch(function(err) {
                         logger.error('Error in callback of the notification listener %b.', dataNotification, err.stack || err);
                     });
                 } else {
@@ -428,8 +428,7 @@ function notifyChangeListeners(tenantId, dataNotification, notificationType, rec
  * @param <object> record: Object/Record to notify to listening publication
  * 
  */
-function notifyCluster(tenantId, dataNotification, record, options) {
-}
+function notifyCluster(tenantId, dataNotification, record, options) {}
 
 /**
  * 
@@ -473,7 +472,7 @@ function Subscription(user, subscriptionId, publication, params) {
 
     // this give an opportunity for the publication to set additional parameters that will be use during fetching.
     if (publication.init) {
-        publication.init(this.tenantId, this.user, additionalParams);// should be(this.user,additionalParams,excludedParams)
+        publication.init(this.tenantId, this.user, additionalParams); // should be(this.user,additionalParams,excludedParams)
     }
 
 
@@ -492,17 +491,17 @@ function Subscription(user, subscriptionId, publication, params) {
         debugSub(thisSub, 'Feching all data now');
         try {
             return this.publication.fn(sub.tenantId, sub.user, this.params)
-                .then(function (result) {
+                .then(function(result) {
                     var records = toArray(result);
-                    if (!records || records.length == 0) {
-                        emitNoDataAtInit();
-                    } else {
-                        records.forEach(addToQueue);
-                        emitQueue(true);
-                    }
+                    // if (!records || records.length == 0) {
+                    //     emitNoDataAtInit();
+                    // } else {
+                    records.forEach(addToQueue);
+                    emitQueue(true);
+                    //                    }
                     return; // does not return a promise here on purpose (non blocking)
                 })
-                .catch(function (err) {
+                .catch(function(err) {
                     // unrecoverable error... check your fetch code.
                     logger.error(err, err.stack);
                 });
@@ -512,18 +511,19 @@ function Subscription(user, subscriptionId, publication, params) {
         }
     }
 
-    function emitNoDataAtInit() {
-        thisSub.socket.emit('SYNC_NOW', { name: thisSub.publication.name, subscriptionId: thisSub.id, records: [], params: thisSub.params }, function (response) {
-            initialPushCompleted = true;
-        });
-    }
+    // function emitNoDataAtInit() {
+    //     thisSub.socket.emit('SYNC_NOW', { name: thisSub.publication.name, subscriptionId: thisSub.id, records: [], params: thisSub.params }, function(response) {
+    //         initialPushCompleted = true;
+
+    //     });
+    // }
 
     function emitQueue(isAllRecords) {
         var recordsToProcess = readQueue();
-        if (recordsToProcess.length == 0) {
-            debugSub(thisSub, 'No data to emit');
-            return;
-        }
+        // if (recordsToProcess.length == 0) {
+        //     debugSub(thisSub, 'No data to emit');
+        //     return;
+        // }
 
         if (!thisSub.socket) {
             debugSub(thisSub, 'Emit canceled. Subscription no longer bound and pending destruction.');
@@ -531,22 +531,38 @@ function Subscription(user, subscriptionId, publication, params) {
         }
 
         logSub(thisSub, 'Emitting data: ' + recordsToProcess.length);
+        // logSub(thisSub, 'Emitting data: ' + recordsToProcess.length + '-' + _.filter(recordsToProcess, function(r) {
+        //     return r.remove;
+        // }).length + ' - ' + _.map(recordsToProcess, function(r) { return r.ct; }));
+
         thisSub.timestamp = getMaxTimestamp(thisSub.timestamp, recordsToProcess);
 
-        thisSub.socket.emit('SYNC_NOW', { name: thisSub.publication.name, subscriptionId: thisSub.id, records: recordsToProcess, params: thisSub.params, diff: !isAllRecords }, function (response) {
-            // The client acknowledged. now we are sure that the records were received.
-            removeFromQueue(recordsToProcess);
+        // remove the data about to get submitted from the queue
+        //removeFromQueue(recordsToProcess);
 
+        // submit the data, socketio will make sure that the data is received by the client
+        // if there is a network failure, the client will resubscribe and get the data.
+        thisSub.socket.emit('SYNC_NOW', { name: thisSub.publication.name, subscriptionId: thisSub.id, records: recordsToProcess, params: thisSub.params, diff: !isAllRecords }, function(response) {
+
+            // ------------------------------------------------------------------------------------------------
+            removeFromQueue(recordsToProcess); // DOES NOT WORK HERE ON HEAVYLOAD... something is wrong. 
+            // scenario seems: subscribe, notify a new record (rev:1), then notify delete (rev 2) right after notifying creation. do it many times quickly (load test)
+            // does not delete sometimes, despite the dispose on the client seems to work as expected..
+            // the record seems to have arrived on client (not sure 100%)
+            // seems that the initial fetch might not happen at the right time, maybe after the notify delete.. then the client clearCache so the delete
+            // Placing removeFromQueue above made it work perfectly. why?
+            // ------------------------------------------------------------------------------------------------
+
+            // The client acknowledged. now we are sure that the records were received.
             initialPushCompleted = true;
             // if the publication is supposed to push the data only once...release subscription
             if (thisSub.publication.once) {
                 release();
             }
-            // otherwise if something was added to the queue meantime...let's process again..
+            // // otherwise if something was added to the queue meantime...let's process again..
             else if (getQueueLength() > 0) {
                 emitQueue();
             }
-
         });
         return; // does not return a promise here on purpose (non blocking)
     }
@@ -555,26 +571,34 @@ function Subscription(user, subscriptionId, publication, params) {
         if (notificationType === 'REMOVAL') {
             record.remove = new Date();
         }
-        addToQueue(record);
-        // if there is more than one record currently in the queue...it means client has not gotten all the data yet. Could be due a slow or lost of connection. but...so let's wait it finishes and avoid emitting again.
-        // the emitCache function will catch up and try to empty the queue anyway.
-        if (initialPushCompleted && getQueueLength() == 1) {
-            emitQueue();
+        if (addToQueue(record)) {
+            // if there is more than one record currently in the queue...it means client has not gotten all the data yet. Could be due a slow or lost of connection/ async processing. but...so let's wait it finishes and avoid emitting again.
+            // the emitCache function will catch up and try to empty the queue anyway.
+            if (initialPushCompleted && getQueueLength() == 1) {
+                emitQueue();
+            } else {
+                logger.warn('Not emitting yet ' + record.ct + ' to subscription id ' + subscriptionId);
+            }
         }
     }
 
     function addToQueue(record) {
         var previous = queue[getIdValue(record.id)];
         // add to queue only if it is a version more recent
-        if (!previous || getRecordRevision(previous) !== null || getRecordRevision(previous) < getRecordRevision(record)) {
+        if (!previous || getRecordRevision(previous) < getRecordRevision(record)) {
+
+            // if (!previous || getRecordRevision(previous) !== null || getRecordRevision(previous) < getRecordRevision(record)) {
             queue[getIdValue(record.id)] = record;
+            return true;
         }
+        return false;
     }
 
     function removeFromQueue(records) {
-        records.forEach(function (record) {
+        records.forEach(function(record) {
             var previous = queue[getIdValue(record.id)];
-            if (!previous || getRecordRevision(previous) !== null || getRecordRevision(previous) <= getRecordRevision(record)) {
+            //            if (!previous || getRecordRevision(previous) !== null || getRecordRevision(previous) <= getRecordRevision(record)) {
+            if (!previous || getRecordRevision(previous) <= getRecordRevision(record)) {
                 // remove record fromo queue only except if there is already a new version more recent (Might just have been notified)
                 delete queue[getIdValue(record.id)];
                 //logSub(sub, 'Dropping queue to:'+readQueue().length);
@@ -587,7 +611,7 @@ function Subscription(user, subscriptionId, publication, params) {
             return id;
         }
         // build composite key value
-        var r = _.join(_.map(id, function (value) {
+        var r = _.join(_.map(id, function(value) {
             return value;
         }), '~');
         return r;
@@ -648,7 +672,7 @@ function Subscription(user, subscriptionId, publication, params) {
         // ex a subscription might pass some params not useful such as startDate, endDate, type... which are not useful for notification.
 
         var identityParams = _.assign({}, this.params);
-        _.forEach(this.additionalParams, function (p) {
+        _.forEach(this.additionalParams, function(p) {
             if (thisSub.additionalParams[p] === null) {
                 delete identityParams[p];
             }
@@ -710,13 +734,13 @@ function Subscription(user, subscriptionId, publication, params) {
     }
 
     function toArray(result) {
-        var records;
-        if (Object.prototype.toString.call(result) === '[object Array]') {
-            records = result;
-        } else if (result !== null) {
-            records = [result];
+        if (_.isArray(result)) {
+            return result;
         }
-        return records;
+        if (result !== null) {
+            return [result];
+        }
+        return [];
     }
 
     /**
@@ -780,17 +804,17 @@ function bindSubscriptionToSocket(subscription, socket) {
 }
 
 function unbindAllSubscriptionOnSocketDisconnect(socket) {
-    socket.on('disconnect', function () {
+    socket.on('disconnect', function() {
         // release socket instance from its subscriptions...
         var socketSubscriptions = socket.subscriptions;
         socket.subscriptions = [];
-        socketSubscriptions.forEach(function (subscription) {
+        socketSubscriptions.forEach(function(subscription) {
             debugSub(subscription, 'Unbound due to disconnection.');
             subscription.socket = null;
         });
         // then give a change to reuse the subscription if the client reconnects fast enough, otherwise unsubscribe all subscriptions from this socket.
-        setTimeout(function () {
-            socketSubscriptions.forEach(function (subscription) {
+        setTimeout(function() {
+            socketSubscriptions.forEach(function(subscription) {
                 // if there is a socket it would be a new one, not the one is disconnected.  so the subscription has been reactivated on the new socket (client reconnected)
                 if (!subscription.socket) {
                     debugSub(subscription, 'Timeout. Discarding Subscription. No longer in use.');
@@ -809,5 +833,3 @@ function logSub(subscription, text) {
 function debugSub(subscription, text) {
     logger.debug(subscription.user.display + ': Sub %b/id%b - ' + text, subscription.publication.name, subscription.id);
 }
-
-

--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -214,10 +214,18 @@ function clear() {
 /**
  * Define a new publication which can be subscribe to.
  * 
- * @param name : the name of the publication the client can subscripbe too
- * @param fetchFn: the function that will return a promise with the array of data pulled. this function will receive the params passed by the subscription if any.
- * @param dataNotification:   currently, this is a single string (not a Class). When data is updated, deleted or added, it should be notified with this value
- * @param options: object with followings:
+ * @param <string> name : the name of the publication the client can subscripbe too
+ * @param <function> fetchFn: the function that will return a promise with the array of data pulled. this function will receive the params passed by the subscription if any.
+ * @param <string or object> dataNotification. When data is updated, deleted or added, it should be notified with this value for the publication to push the changes (if they match its subscription params)
+ *          - <string> representing the notification event.
+ *          - <Object> object with property name being the event, the value being the function to execute againt the object/record to be notified.following properties
+ *            ex: publication of census (each time a adult registration is updated/created, the subscription to this publication will receive this person)
+ *              {
+ *                  ADULT: function(adultRegistration) { return new Person( adultRegistration); }}    
+ *                  CHILD: function(childRegistration) { return new Person(childRegistration);}
+ *              }
+ *                 
+ * @param <object> options: object with followings:
  *        init: function to provided additional params that will be used to check if a subscription listens to the notified data(new, updated or removed data),
 */
 function publish(name, fetchFn, dataNotification, options) {
@@ -631,10 +639,11 @@ function Subscription(user, subscriptionId, publication, params) {
 
         var identityParams = _.assign({}, this.params);
         _.forEach(this.additionalParams, function (p) {
-            if (this.additionalParams[p] === null) {
+            if (thisSub.additionalParams[p] === null) {
                 delete identityParams[p];
             }
         });
+
         return checkIfIncluded(identityParams, dataParams);
 
         // if TASK_DATA is notified with object containing(planId:5) and subscription params were for ie: (planId:5, status:'active')

--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -280,8 +280,9 @@ function onDataChanges(dataNotification, callback) {
  * @deprecated since it does not pass the tenantId, use notifyUpdate or notifyCreation
  * 
  */
-function notifyChanges(dataNotification, record, options) {
-    // need to remove that code
+function notifyChanges(dataNotification, object, options) {
+    logger.warn('notifyChanges() is deprecated. Use notifyCreate or notifyUpdate instead');
+    var record = serialize(object);
     notifyRecordActivity(null, dataNotification, record, options)
 }
 
@@ -290,7 +291,9 @@ function notifyChanges(dataNotification, record, options) {
  * @deprecated since it does not pass the tenantId. use notifyDelete
  * 
  */
-function notifyRemoval(dataNotification, record) {
+function notifyRemoval(dataNotification, object) {
+    logger.warn('notifyRemoval() is deprecated. Use notifyDelete instead.');
+    var record = serialize(object);
     record.remove = new Date();
     notifyChanges(dataNotification, record);
 }
@@ -303,7 +306,8 @@ function notifyRemoval(dataNotification, record) {
  * @param record: Object/Record to notify to listening publication (must at least have an id and revision number)
  * 
  */
-function notifyDelete(tenantId, dataNotification, record, options) {
+function notifyDelete(tenantId, dataNotification, object, options) {
+    var record = serialize(object);
     record.remove = new Date();
     notifyRecordActivity(tenantId, dataNotification, record, options);
 }
@@ -318,7 +322,8 @@ function notifyDelete(tenantId, dataNotification, record, options) {
  * Notes:
  * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
  */
-function notifyUpdate(tenantId, dataNotification, record, options) {
+function notifyUpdate(tenantId, dataNotification, object, options) {
+    var record = serialize(object);
     record.update = true;
     notifyRecordActivity(tenantId, dataNotification, record, options);
 }
@@ -333,14 +338,18 @@ function notifyUpdate(tenantId, dataNotification, record, options) {
  * Notes:
  * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
  */
-function notifyCreation(tenantId, dataNotification, record, options) {
+function notifyCreation(tenantId, dataNotification, object, options) {
+    var record = serialize(object);
     record.update = false;
     notifyRecordActivity(tenantId, dataNotification, record, options);
 }
 
 
 ////////////////// HELPERS //////////////////////
-
+function serialize(object) {
+    // When the subscription params are checked against the object notified to sync, the object must be serialized so it contains ids, no object references. Subscription params are id based.
+    return JSON.parse(JSON.stringify(object));
+}
 
 function notifyRecordActivity(tenantId, dataNotification, record, options) {
     options = options || {}
@@ -351,7 +360,7 @@ function notifyRecordActivity(tenantId, dataNotification, record, options) {
     findPublicationsListeningToDataNotification(dataNotification)
         .forEach(function (publication) {
 
-            publication.dataNotifications[dataNotification](record, record.remove).then(function (record) {
+            publication.dataNotifications[dataNotification](record, record.remove ? 'REMOVAL' : record.update ? 'UPDATE' : 'ADD', publication.params).then(function (record) {
 
                 findSubscriptionsUsingPublication(publication.name)
                     .forEach(function (subscription) {
@@ -451,7 +460,7 @@ function Subscription(user, subscriptionId, publication, params) {
 
     // this give an opportunity for the publication to set additional parameters that will be use during fetching.
     if (publication.init) {
-        publication.init(this.tenantId, this.user, additionalParams);
+        publication.init(this.tenantId, this.user, additionalParams);// should be(this.user,additionalParams,excludedParams)
     }
 
 
@@ -597,9 +606,40 @@ function Subscription(user, subscriptionId, publication, params) {
 
 
     function checkIfMatch(dataParams) {
+
+        // seid
+        // sds.subscribe('forecast.sync',{opportunityId:id,type:'monthly'});
+        //
+        // In forecast, after calculating notify FORECAST_UPDATE
+        //
+        // zerv.publication('forecast.sync',
+        // function(tenantId,user,seidParams) {
+        //   forecast.getData(seidParams.opportunitId,seidParams.type)
+        // }),
+        // {
+        //    FORECAST_DATA:function(notifiedData,status,params){  // params should be passed
+        // 
+        //          forecast.getData(notifiedData.opportunitId,params.type);
+        // },
+        // {init:function(tenant,user, params) {
+        //      params.type = null;        
+        //}}
+
+
+        // if additional params has a null param, the params should not be used as identityParams
+        // ex a subscription might pass some params not useful such as startDate, endDate, type... which are not useful for notification.
+
+        var identityParams = _.assign({}, this.params);
+        _.forEach(this.additionalParams, function (p) {
+            if (this.additionalParams[p] === null) {
+                delete identityParams[p];
+            }
+        });
+        return checkIfIncluded(identityParams, dataParams);
+
         // if TASK_DATA is notified with object containing(planId:5) and subscription params were for ie: (planId:5, status:'active')
         // the subscription would run the publication.
-        return checkIfIncluded(this.params, dataParams) && checkIfIncluded(this.additionalParams, dataParams);
+        // return checkIfIncluded(this.params, dataParams) && checkIfIncluded(this.additionalParams, dataParams);
     }
 
     function checkIfIncluded(keyParams, record) {

--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -493,12 +493,8 @@ function Subscription(user, subscriptionId, publication, params) {
             return this.publication.fn(sub.tenantId, sub.user, this.params)
                 .then(function(result) {
                     var records = toArray(result);
-                    // if (!records || records.length == 0) {
-                    //     emitNoDataAtInit();
-                    // } else {
                     records.forEach(addToQueue);
                     emitQueue(true);
-                    //                    }
                     return; // does not return a promise here on purpose (non blocking)
                 })
                 .catch(function(err) {
@@ -511,47 +507,24 @@ function Subscription(user, subscriptionId, publication, params) {
         }
     }
 
-    // function emitNoDataAtInit() {
-    //     thisSub.socket.emit('SYNC_NOW', { name: thisSub.publication.name, subscriptionId: thisSub.id, records: [], params: thisSub.params }, function(response) {
-    //         initialPushCompleted = true;
-
-    //     });
-    // }
 
     function emitQueue(isAllRecords) {
         var recordsToProcess = readQueue();
-        // if (recordsToProcess.length == 0) {
-        //     debugSub(thisSub, 'No data to emit');
-        //     return;
-        // }
 
         if (!thisSub.socket) {
             debugSub(thisSub, 'Emit canceled. Subscription no longer bound and pending destruction.');
             return;
         }
 
-        logSub(thisSub, 'Emitting data: ' + recordsToProcess.length);
-        // logSub(thisSub, 'Emitting data: ' + recordsToProcess.length + '-' + _.filter(recordsToProcess, function(r) {
-        //     return r.remove;
-        // }).length + ' - ' + _.map(recordsToProcess, function(r) { return r.ct; }));
+        logSub(thisSub, 'Emitting data from current queue: ' + recordsToProcess.length);
 
         thisSub.timestamp = getMaxTimestamp(thisSub.timestamp, recordsToProcess);
-
-        // remove the data about to get submitted from the queue
-        //removeFromQueue(recordsToProcess);
 
         // submit the data, socketio will make sure that the data is received by the client
         // if there is a network failure, the client will resubscribe and get the data.
         thisSub.socket.emit('SYNC_NOW', { name: thisSub.publication.name, subscriptionId: thisSub.id, records: recordsToProcess, params: thisSub.params, diff: !isAllRecords }, function(response) {
 
-            // ------------------------------------------------------------------------------------------------
-            removeFromQueue(recordsToProcess); // DOES NOT WORK HERE ON HEAVYLOAD... something is wrong. 
-            // scenario seems: subscribe, notify a new record (rev:1), then notify delete (rev 2) right after notifying creation. do it many times quickly (load test)
-            // does not delete sometimes, despite the dispose on the client seems to work as expected..
-            // the record seems to have arrived on client (not sure 100%)
-            // seems that the initial fetch might not happen at the right time, maybe after the notify delete.. then the client clearCache so the delete
-            // Placing removeFromQueue above made it work perfectly. why?
-            // ------------------------------------------------------------------------------------------------
+            removeFromQueue(recordsToProcess);
 
             // The client acknowledged. now we are sure that the records were received.
             initialPushCompleted = true;
@@ -567,6 +540,15 @@ function Subscription(user, subscriptionId, publication, params) {
         return; // does not return a promise here on purpose (non blocking)
     }
 
+    /**
+     * Emit a change.
+     * 
+     * Due to async nature, a notification for change might occur before the subscription has received the initial data.
+     * In this scenario, the change will be queued.
+     * 
+     * @param <Object> the record to push to the client subscription
+     * @param <String> the type (REMOVAL,ADD,UPDATE)
+     */
     function emitChange(record, notificationType) {
         if (notificationType === 'REMOVAL') {
             record.remove = new Date();
@@ -576,18 +558,16 @@ function Subscription(user, subscriptionId, publication, params) {
             // the emitCache function will catch up and try to empty the queue anyway.
             if (initialPushCompleted && getQueueLength() == 1) {
                 emitQueue();
-            } else {
-                logger.warn('Not emitting yet ' + record.ct + ' to subscription id ' + subscriptionId);
             }
         }
     }
 
     function addToQueue(record) {
+        var rev = getRecordRevision(record);
         var previous = queue[getIdValue(record.id)];
         // add to queue only if it is a version more recent
-        if (!previous || getRecordRevision(previous) < getRecordRevision(record)) {
-
-            // if (!previous || getRecordRevision(previous) !== null || getRecordRevision(previous) < getRecordRevision(record)) {
+        if (!previous || getRecordRevision(previous) < rev) {
+            debugSub(thisSub, 'Adding record #' + record.id + ', revision ' + rev + ' to queue');
             queue[getIdValue(record.id)] = record;
             return true;
         }
@@ -597,7 +577,6 @@ function Subscription(user, subscriptionId, publication, params) {
     function removeFromQueue(records) {
         records.forEach(function(record) {
             var previous = queue[getIdValue(record.id)];
-            //            if (!previous || getRecordRevision(previous) !== null || getRecordRevision(previous) <= getRecordRevision(record)) {
             if (!previous || getRecordRevision(previous) <= getRecordRevision(record)) {
                 // remove record fromo queue only except if there is already a new version more recent (Might just have been notified)
                 delete queue[getIdValue(record.id)];

--- a/package.json
+++ b/package.json
@@ -1,33 +1,33 @@
 {
-  "name": "zerv-sync",
-  "version": "1.0.1",
-  "description": "Zerv module providing data synchronization support",
-  "main": "lib/server-sync.js",
-  "keywords": [
-    "socket",
-    "socket.io",
-    "jwt"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/z-open/zerv-sync.git"
-  },
-  "scripts": {
-    "test": "./node_modules/jasmine/bin/jasmine.js"
-  },
-  "license": "MIT",
-  "dependencies": {
-    "express": "^4.14.0",
-    "jsonwebtoken": "^5.0.0",
-    "lodash": "^4.15.0",
-    "promise": "^7.1.1",
-    "request": "^2.74.0",
-    "zerv-core": "git://github.com/z-open/zerv-core#1.0.0",
-    "uuid": "^2.0.1",
-    "xtend": "~2.1.2",
-    "zlog": "git://github.com/z-open/zlog#1.0.0"
-  },
-  "devDependencies": {
-    "jasmine": "^2.4.1"
-  }
+    "name": "zerv-sync",
+    "version": "1.0.2",
+    "description": "Zerv module providing data synchronization support",
+    "main": "lib/server-sync.js",
+    "keywords": [
+        "socket",
+        "socket.io",
+        "jwt"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/z-open/zerv-sync.git"
+    },
+    "scripts": {
+        "test": "./node_modules/jasmine/bin/jasmine.js"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "express": "^4.14.0",
+        "jsonwebtoken": "^5.0.0",
+        "lodash": "^4.15.0",
+        "promise": "^7.1.1",
+        "request": "^2.74.0",
+        "zerv-core": "git://github.com/z-open/zerv-core#1.0.0",
+        "uuid": "^2.0.1",
+        "xtend": "~2.1.2",
+        "zlog": "git://github.com/z-open/zlog#1.0.0"
+    },
+    "devDependencies": {
+        "jasmine": "^2.4.1"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-sync",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Zerv module providing data synchronization support",
   "main": "lib/server-sync.js",
   "keywords": [


### PR DESCRIPTION
Fixed issue with mapping not being applied when an object of a dependent subscription is removed. The client side (zerv-ng-sync bower module) had to be modified too.

The issue would only show during a load test. (Repeating the following: create new subscription, create , delete record).

The issue was related to the queue not updating properly due to wrong revision condition.

