### PR TITLE
Fixed notification not handling tenant specific

### DIFF
--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -657,9 +657,13 @@ function Subscription(user, subscriptionId, publication, params) {
         // ex a subscription might pass some params not useful such as startDate, endDate, type... which are not useful for notification.
 
         var identityParams = _.assign({}, this.params);
-        _.forEach(this.additionalParams, function (p) {
+        _.forEach(this.additionalParams, function (value, p) {
             if (thisSub.additionalParams[p] === null) {
+                //the object notified does NOT need to contain this value to be identified
                 delete identityParams[p];
+            } else {
+                //otherwise the object notified would need to contain this value to be identified
+                identityParams[p] = value;
             }
         });
 

--- a/lib/server-sync.js
+++ b/lib/server-sync.js
@@ -368,7 +368,7 @@ function notifyRecordActivity(tenantId, dataNotification, notificationType, obje
 
             publication.dataNotifications[dataNotification](object, notificationType, publication.params).then(function (record) {
 
-                findSubscriptionsUsingPublication(publication.name)
+                findSubscriptionsUsingPublication(tenantId, publication.name)
                     .forEach(function (subscription) {
                         try {
                             // make sure that the subscription is matching the notification params..so that we don't call the db for nothing!!
@@ -550,7 +550,7 @@ function Subscription(user, subscriptionId, publication, params) {
      * @param <String> the type (REMOVAL,ADD,UPDATE)
      */
     function emitChange(record, notificationType) {
-        
+
         if (_.isFunction(record.toJSON)) {
             // if the object has a toJSON this will mostlikely remove the remove flag that is added later.
             record = _.assign({}, record.toJSON());
@@ -746,11 +746,12 @@ function Subscription(user, subscriptionId, publication, params) {
     }
 }
 
-function findSubscriptionsUsingPublication(publicationName) {
+function findSubscriptionsUsingPublication(tenantId, publicationName) {
     var r = [];
+
     for (var id in activeSubscriptions) {
         var subscription = activeSubscriptions[id];
-        if (subscription.publication.name === publicationName) {
+        if (subscription.publication.name === publicationName && subscription.tenantId === tenantId) {
             r.push(subscription);
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zerv-sync",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "description": "Zerv module providing data synchronization support",
     "main": "lib/server-sync.js",
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zerv-sync",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Zerv module providing data synchronization support",
     "main": "lib/server-sync.js",
     "keywords": [

--- a/spec/server-sync.spec.js
+++ b/spec/server-sync.spec.js
@@ -5,6 +5,7 @@ var sync = require("../lib/server-sync");
 var Promise = require('promise');
 var socket;
 var handler;
+var tenantId;
 var userId;
 var subscription;
 var deferredEmit, deferredFetch;
@@ -30,13 +31,14 @@ describe("Sync", function () {
         deferredEmit = defer();
         deferredFetch = defer();
 
+        tenantId = 'TID';
         userId = 'UID1234';
 
         socket = new MockSocket();
 
         handler = {
             user: {
-                tenantId: 'TID',
+                tenantId,
                 id: userId,
                 display: 'John'
             },
@@ -45,7 +47,7 @@ describe("Sync", function () {
 
         handler2 = {
             user: {
-                tenantId: 'TID',
+                tenantId,
                 id: 'U2',
                 display: 'Mike'
             },
@@ -194,7 +196,7 @@ describe("Sync", function () {
         });
         it("should receive an update", function (done) {
             waitForNotification().then(function (sub1) {
-                sync.notifyChanges('MAGAZINE_DATA', magazine1b);
+                sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1b);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.diff).toBe(true);
                     expect(sub2.records.length).toBe(1);
@@ -206,7 +208,7 @@ describe("Sync", function () {
 
         it("should receive an addition", function (done) {
             waitForNotification().then(function (sub1) {
-                sync.notifyChanges('MAGAZINE_DATA', magazine3);
+                sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine3);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.diff).toBe(true);
                     expect(sub2.records.length).toBe(1);
@@ -218,7 +220,7 @@ describe("Sync", function () {
 
         it("should receive a removal", function (done) {
             waitForNotification().then(function (sub1) {
-                sync.notifyRemoval('MAGAZINE_DATA', magazine2Deleted);
+                sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2Deleted);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.diff).toBe(true);
                     expect(sub2.records.length).toBe(1);
@@ -231,7 +233,7 @@ describe("Sync", function () {
             waitForNotification().then(function (sub1) {
                 // the client decides if its cache need to remove magazine revision number
                 // server does not keep track of what is on the client
-                sync.notifyRemoval('MAGAZINE_DATA', magazine2);
+                sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.records.length).toBe(1);
                     done();
@@ -248,7 +250,7 @@ describe("Sync", function () {
 
         it("should receive an update", function (done) {
             waitForNotification().then(function (sub1) {
-                sync.notifyChanges('MAGAZINE_DATA', magazine1b);
+                sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1b);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.records.length).toBe(1);
                     done();
@@ -258,7 +260,7 @@ describe("Sync", function () {
 
         it("should receive an addition", function (done) {
             waitForNotification().then(function (sub1) {
-                sync.notifyChanges('MAGAZINE_DATA', magazine4);
+                sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine4);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.records.length).toBe(1);
                     done();
@@ -269,7 +271,7 @@ describe("Sync", function () {
 
         it("should receive a removal", function (done) {
             waitForNotification().then(function (sub1) {
-                sync.notifyRemoval('MAGAZINE_DATA', magazine2Deleted);
+                sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2Deleted);
                 waitForNotification().then(function (sub2) {
                     expect(sub2.records.length).toBe(1);
                     done();
@@ -284,7 +286,7 @@ describe("Sync", function () {
                 })
                 .then(waitForNotification)
                 .then(function (sub1) {
-                    sync.notifyChanges('MAGAZINE_DATA', magazine3);
+                    sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine3);
                     expect(socket.emit.calls.count()).toBe(1);
                     done();
                 });
@@ -299,7 +301,7 @@ describe("Sync", function () {
                 })
                 .then(waitForNotification)
                 .then(function (sub1) {
-                    sync.notifyChanges('MAGAZINE_DATA', magazine3b);
+                    sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine3b);
                     expect(socket.emit.calls.count()).toBe(1);
                     done();
                 });
@@ -314,7 +316,7 @@ describe("Sync", function () {
                 .then(waitForNotification)
                 .then(function (sub1) {
                     debugger
-                    sync.notifyChanges('MAGAZINE_DATA', magazine3Deleted);
+                    sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine3Deleted);
                     expect(socket.emit.calls.count()).toBe(1);
                     done();
                 });


### PR DESCRIPTION
Fixed: when notify an update, creation or delete, the sync would push to any publication disregarding the tenantId.