### PR TITLE
5800 - ET - Fix removal notifications sent multiple times

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,9 @@
             "type": "node",
             "request": "launch",
             "name": "Test",
-            "program": "${workspaceFolder}/node_modules/jasmine/bin/jasmine.js"
+            "program": "${workspaceFolder}/node_modules/jasmine/bin/jasmine.js",
+            "args": ["spec/zerv-sync.spec.js"],
+
         },
         {
             "name": "Launch",
@@ -13,7 +15,7 @@
             "request": "launch",
             "program": "${workspaceRoot}/node_modules/jasmine/bin/jasmine.js",
             "stopOnEntry": false,
-            "args": [],
+            "args": ["spec/zerv-sync.spec.js"],
             "cwd": "${workspaceRoot}",
             "preLaunchTask": null,
             "runtimeExecutable": null,

--- a/lib/clustering.js
+++ b/lib/clustering.js
@@ -192,7 +192,7 @@ function _processMessage(transport, channel, message, processRecordNotifications
         json = transport.deserialize(message);
     // redis messages originating from the same server are not processed again since they are already processed.
         if (json && json.zervId !== zervId) {
-            logger.debug('Received cluster sync notification on channel %b', channel);
+            logger.debug('Received cluster sync notification on channel %b: %s, %s, %s object(s)', channel, json.dataNotification, json.notificationType, json.objects.length);
             processRecordNotifications(json.tenantId, json.dataNotification, json.notificationType, json.objects, json.options);
         }
     } catch (err) {

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -36,59 +36,77 @@ function Publication(name, fetchFn, dataNotifications, options) {
  *                                      This can help to force the publication to reaply their filter
  *                                      and re-add an object that was removed
  *
+ *  @returns {Promise<number>} number of notifications which are scheduled to be emitted to the interested subscriptions.
+ * 
  */
-Publication.prototype.notifySubscriptions = function(tenantId, dataNotification, notificationType, objects, options) {
-    const thisPublication = this;
-    const tenantSubs = thisPublication.findSubscriptionsByTenantId(tenantId);
+Publication.prototype.notifySubscriptions = async function(tenantId, dataNotification, notificationType, objects, options) {
+    const promises = [];
+    const tenantSubs = this.findSubscriptionsByTenantId(tenantId);
     if (!tenantSubs.length) {
         return;
     }
-    thisPublication.preFormatNotifiedObjects(dataNotification, objects, notificationType)
-      .then(function(records) {
-          tenantSubs
-            .forEach(function(subscription) {
+    try {
+        const records = await this.preFormatNotifiedObjects(dataNotification, objects, notificationType);
 
-                if (!_.isNil(options.onlyUserId) && options.onlyUserId !== subscription.userId ) {
-                // make sure only the specified user is notified, if option is provided.
-                    return ;
-                }
-              // if alwaysFetch, all the records will be retrieved and pushed each time there is a notification (Db performance impact)
-              // this can be useful for join query if data is defined with a proper record ID and revision number
-                if (thisPublication.always) {
-                    return subscription.emitAllRecords();
-                }
+        for (const subscription of tenantSubs) {
+            if (!_.isNil(options.onlyUserId) && options.onlyUserId !== subscription.userId ) {
+            // make sure only the specified user is notified, if option is provided.
+                continue ;
+            }
+            promises.push(this.emitRecordsToSubscription(subscription, records, dataNotification, notificationType, options));
+        }
+    } catch(err) {
+        logger.error(err, err.stack); ;
+    }
+    return Promise.all(promises).then(_.sum);
+};
 
-                return thisPublication.formatNotifiedObjectsWithSubscriptionParams(dataNotification, records, notificationType, subscription)
-                  .then(async (records) => {
-                      const subRecords = [];
-                      for (const record of records) {
+Publication.prototype.emitRecordsToSubscription = async function(subscription, records, dataNotification, notificationType, options) {
+    // if alwaysFetch, all the records will be retrieved and pushed each time there is a notification (Db performance impact)
+    // this can be useful for join query if data is defined with a proper record ID and revision number
+    if (this.always) {
+        return subscription.emitAllRecords();
+    }
 
-                        // this loop can be very demanding due to number of loops.
-                        // notify functions can be used to notify thousands and thousands of objects in servers with many publications/subscriptions, 
-                        // notifySubscriptions could take over the node process if no async functions await any resources.api responsive) and even the server,
-                        // freeing event queue will help:
-                          await utils.breath();
+    const formattedRecords = await this.formatNotifiedObjectsWithSubscriptionParams(dataNotification, records, notificationType, subscription);
 
-                          try {
-                        // make sure that the subscription is matching the notification params otherwise it might be a record that might need to be removed
-                              const isMatch = await subscription.checkIfMatch(record, dataNotification);
-                              const type = ! isMatch ? 'REMOVAL' : notificationType;
+    const promises = [];
+    const subRecords = [];
+    for (const record of formattedRecords) {
+        // this loop can be very demanding due to number of loops.
+        // notify functions can be used to notify thousands and thousands of objects in servers with many publications/subscriptions, 
+        // notifySubscriptions could take over the event loop and the entire node process.
+        // freeing event queue will help by pausing adding more promises to the event loop at least in regarg to notification processing.
+        await utils.breath();
 
-                              subRecords.push({record, type});
-                          } catch (err) {
-                        // unrecoverable error... check record validity.
-                              logger.error(err, err.stack);
-                          }
-                      }
-                      if (subRecords.length) {
-                          subscription.emitChanges(subRecords, options.forceNotify);
-                      }
-                  });
-            });
-      })
-      .catch(function(err) {
-          logger.error(err, err.stack); ;
-      });
+        // figuring out what to emit is NOT serialized as the process depends on other asynchronous processes.
+        promises.push((async () => {
+            const recordToEmitBasedOnSubscriptionState = await this.prepareRecordToEmitToSubscription(subscription, record, dataNotification, notificationType);
+            if (recordToEmitBasedOnSubscriptionState) {
+                subRecords.push(recordToEmitBasedOnSubscriptionState);
+            } 
+        })());
+    }
+    return Promise.all(promises)
+    .then(() => {
+        if (!subRecords.length) {
+            return 0;
+        }
+        return subscription.emitChanges(subRecords, options.forceNotify);
+    });
+};
+
+Publication.prototype.prepareRecordToEmitToSubscription= async function(subscription, record, dataNotification, notificationType) {
+    try {
+        // make sure that the subscription is matching the notification params otherwise it might be a record that might need to be removed
+        const isMatch = await subscription.checkIfMatch(record, dataNotification);
+        const type = !isMatch ? 'REMOVAL' : notificationType;
+        return { record, type };
+    } catch (err) {
+        // unrecoverable error... check record validity.
+        logger.error(err, err.stack);
+        return null;
+    }
 };
 
 Publication.prototype.addSubscription = function(user, subscriptionId, params) {
@@ -132,7 +150,7 @@ Publication.prototype.formatNotifiedObjectsWithSubscriptionParams = async functi
     ));
 
     async function format(object, notificationType) {
-        await utils.breath();
+        // await utils.breath();
         try {
             const contextParams = _.assign(
                 {tenantId: subscription.tenantId},

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -1,9 +1,8 @@
 'strict mode';
 
-const Promise = require('promise'),
-    zlog = require('zimit-zlog');
 const _ = require('lodash');
-
+const zlog = require('zimit-zlog');
+const utils= require('./utils');
 const Subscription = require('./subscription');
 
 const logger = zlog.getLogger('zerv/sync/publication');
@@ -48,6 +47,11 @@ Publication.prototype.notifySubscriptions = function(tenantId, dataNotification,
       .then(function(records) {
           tenantSubs
             .forEach(function(subscription) {
+
+                if (!_.isNil(options.onlyUserId) && options.onlyUserId !== subscription.userId ) {
+                // make sure only the specified user is notified, if option is provided.
+                    return ;
+                }
               // if alwaysFetch, all the records will be retrieved and pushed each time there is a notification (Db performance impact)
               // this can be useful for join query if data is defined with a proper record ID and revision number
                 if (thisPublication.always) {
@@ -58,10 +62,13 @@ Publication.prototype.notifySubscriptions = function(tenantId, dataNotification,
                   .then(async (records) => {
                       const subRecords = [];
                       for (const record of records) {
-                          if (!_.isNil(options.onlyUserId) && options.onlyUserId !== subscription.userId ) {
-                        // make sure only the specified user is notified, if option is provided.
-                              continue;
-                          }
+
+                        // this loop can be very demanding due to number of loops.
+                        // notify functions can be used to notify thousands and thousands of objects in servers with many publications/subscriptions, 
+                        // notifySubscriptions could take over the node process if no async functions await any resources.api responsive) and even the server,
+                        // freeing event queue will help:
+                          await utils.breath();
+
                           try {
                         // make sure that the subscription is matching the notification params otherwise it might be a record that might need to be removed
                               const isMatch = await subscription.checkIfMatch(record, dataNotification);
@@ -84,7 +91,6 @@ Publication.prototype.notifySubscriptions = function(tenantId, dataNotification,
       });
 };
 
-
 Publication.prototype.addSubscription = function(user, subscriptionId, params) {
     const subscription = new Subscription(user, subscriptionId, this, params);
     this.subscriptions[subscription.id] = subscription;
@@ -98,7 +104,6 @@ Publication.prototype.removeSubscription = function(subscription) {
         sub.release();
     }
 };
-
 
 Publication.prototype.getSubscriptions = function(tenantId) {
     const subs = _.values(this.subscriptions);
@@ -115,20 +120,26 @@ Publication.prototype.findSubscriptionsByTenantId = function(tenantId) {
 };
 
 
-Publication.prototype.formatNotifiedObjectsWithSubscriptionParams = function(dataNotification, objects, notificationType, subscription) {
+Publication.prototype.formatNotifiedObjectsWithSubscriptionParams = async function(dataNotification, objects, notificationType, subscription) {
     const thisPub = this;
-    return Promise.all(_.map(objects, function(object) {
-        return format(dataNotification, object, notificationType);
-    }));
+    const formatFn = thisPub.dataNotifications[dataNotification].format;
+    if (!formatFn) {
+        return objects;
+    }
+    // this could be a large number of objects to format
+    return Promise.all(_.map(objects, (object) => 
+        format(object, notificationType)
+    ));
 
-    function format(dataNotification, object, notificationType) {
+    async function format(object, notificationType) {
+        await utils.breath();
         try {
             const contextParams = _.assign(
                 {tenantId: subscription.tenantId},
                 subscription.params,
                 subscription.additionalParams
             );
-            const r = thisPub.dataNotifications[dataNotification].format(object, notificationType, contextParams);
+            const r = formatFn(object, notificationType, contextParams);
 
             if (!r.then) {
                 return Promise.resolve(r);

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -86,7 +86,7 @@ function Subscription(user, subscriptionId, publication, params) {
                     const records = toArray(result);
                     records.forEach(thisSub._addToQueue);
                     thisSub.flush(true);
-                    return; // does not return a promise here on purpose (non blocking)
+                    return records.length;
                 })
                 .catch(function(err) {
                     // unrecoverable error... check your fetch code.
@@ -153,11 +153,11 @@ function Subscription(user, subscriptionId, publication, params) {
        *
        * @param {Array} notifications of objects to push to the client subscription
        * @param {boolean} forceNotify
-       * @returns {boolean} true if object records were emitted to the subcription
+       * @returns {Number} true if object records were emitted to the subcription
        *                    false if no object needs to be emitted because the subscription already has the data.
        */
     function emitChanges(notifications, forceNotify) {
-        let changesToEmit = false;
+        let changesToEmit = 0;
         const isQueueEmpty = !getQueueLength();
         for(const notification of notifications) {
             let record;
@@ -168,7 +168,9 @@ function Subscription(user, subscriptionId, publication, params) {
             } else {
                 record = notification.record;
             }
-            changesToEmit = thisSub._addToQueue(record) || changesToEmit;
+            if (thisSub._addToQueue(record)) {
+                changesToEmit++;
+            }
         }
         // if there is more than one record currently in the queue...it means client has not gotten all the data yet. Could be due a slow or lost of connection/ async processing. but...so let's wait it finishes and avoid emitting again.
         // the emitCache function will catch up and try to empty the queue anyway.

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -347,7 +347,7 @@ function Subscription(user, subscriptionId, publication, params) {
             }
         });
 
-        const notificationFilter = publication.dataNotifications[dataNotification].filter;
+        const notificationFilter = _.get(publication.dataNotifications[dataNotification], 'filter');
         if (notificationFilter) {
             // use the custom nofification filter to decide if the object
             // should be sent over to the subscription

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -205,7 +205,7 @@ function Subscription(user, subscriptionId, publication, params) {
 
     function buildRecordForForceUpdate(record) {
         return _.assign({}, record, {
-            revision: recalculateRevision(record)
+            revision: recalculateRevision(record),
         });
     }
 
@@ -233,10 +233,19 @@ function Subscription(user, subscriptionId, publication, params) {
         const revisionToEmit = getRecordRevision(record);
         const clientStateVersion = clientStates[recordId];
 
-        if (!_.isNil(clientStateVersion) && clientStateVersion >= revisionToEmit) {
-            // the client has already acknowledged to have this record or greater revision
-            // don't send it again
-            return false;
+        if (!_.isNil(clientStateVersion)) {
+            
+            if (clientStateVersion >= revisionToEmit) {
+                // the client has already acknowledged to have this record or greater revision
+                // don't send it again
+                return false;
+            }
+
+            if (!record.remove && clientStateVersion === Math.trunc(revisionToEmit)) {
+                // The client has that version, forcing (with the revision offset) would not send any different data
+                return false;
+            }
+
         }
 
         const queuedRecord = queue[recordId];

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -263,10 +263,16 @@ function Subscription(user, subscriptionId, publication, params) {
             const recordRev = getRecordRevision(record);
             const recordId = getIdValue(record.id);
             const clientStateRevision = clientStates[recordId];
-            if ((!clientStateRevision || clientStateRevision < recordRev) && !record.remove) {
-        // keep track of which records client has
-                isDebug() && debugSub(thisSub, 'Adding record #' + recordId + ', revision ' + recordRev + ' to clientStates');
-                clientStates[recordId] = recordRev;
+            if ((!clientStateRevision || clientStateRevision < recordRev)) {
+                if (record.remove) {
+                    // The subscription did receive the removal and does no longer have the record
+                    isDebug() && debugSub(thisSub, 'Removing record #' + recordId + ', revision ' + recordRev + ' to clientStates');
+                    delete clientStates[recordId];
+                } else {
+                    // keep track of which records client has
+                    isDebug() && debugSub(thisSub, 'Adding record #' + recordId + ', revision ' + recordRev + ' to clientStates');
+                    clientStates[recordId] = recordRev;
+                }
             }
         });
         isDebug() && debugSub(thisSub, 'Number of records expected in client: ' + Object.keys(clientStates).length);

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -21,14 +21,14 @@ module.exports = Subscription;
  *
  */
 function Subscription(user, subscriptionId, publication, params) {
-    const additionalParams = {cacheLevel: null};
+    const additionalParams = { cacheLevel: null };
     const queue = {};
     let clientStates = {};
     let initialPushCompleted, onReleaseCallback;
     const thisSub = this;
 
     if (!(user && user.tenantId && user.id)) {
-    // should never happen...but we are in the process of refactor tenantId...
+        // should never happen...but we are in the process of refactor tenantId...
         throw (new Error('Defect: tenantId or userId is null.'));
     }
 
@@ -50,39 +50,50 @@ function Subscription(user, subscriptionId, publication, params) {
     this.checkIfMatch = checkIfMatch;
     this.release = release;
     this.onRelease = onRelease;
+    this.getSyncedRecordVersion = getSyncedRecordVersion;
+    this._addToQueue = _addToQueue;
 
 
-  // this give an opportunity for the publication to set additional parameters that will be use during fetching.
+    // this give an opportunity for the publication to set additional parameters that will be use during fetching.
     if (publication.init) {
         publication.init(this.tenantId, this.user, additionalParams); // should be(this.user,additionalParams,excludedParams)
     }
 
 
-  // ////////////
-
-
-  /**
-     * Retrieved data from persistence storage and push all data to the client.
-     *
-     * @returns promise
+    // ////////////
+    /**
+     * This is record version received by the client on the other side of the socket.
+     * If null, the client does not have this record.
+     * 
+     * @param {String} id 
+     * @returns {Number} record version or null
      */
+    function getSyncedRecordVersion(id) {
+        return clientStates[id];
+    }
+
+    /**
+       * Retrieved data from persistence storage and push all data to the client.
+       *
+       * @returns promise
+       */
     function emitAllRecords() {
         initialPushCompleted = false;
         isDebug() && debugSub(thisSub, 'Feching all data now');
         try {
             return fetchAllData()
-          .then(function(result) {
-              const records = toArray(result);
-              records.forEach(addToQueue);
-              flush(true);
-              return; // does not return a promise here on purpose (non blocking)
-          })
-          .catch(function(err) {
-            // unrecoverable error... check your fetch code.
-              logError(thisSub, 'Fetch failure.', err);
-          });
+                .then(function(result) {
+                    const records = toArray(result);
+                    records.forEach(thisSub._addToQueue);
+                    thisSub.flush(true);
+                    return; // does not return a promise here on purpose (non blocking)
+                })
+                .catch(function(err) {
+                    // unrecoverable error... check your fetch code.
+                    logError(thisSub, 'Fetch failure.', err);
+                });
         } catch (err) {
-      // unrecoverable error... check your fetch code.
+            // unrecoverable error... check your fetch code.
             logError(thisSub, 'Fetch failure.', err);
         }
     }
@@ -98,7 +109,7 @@ function Subscription(user, subscriptionId, publication, params) {
 
     function flush(isAllRecords) {
         if (isAllRecords) {
-      // a change of strategy later on, could be to send ALSO to the client all the client state records as removal if there are not present in the queue. but this could have side effect...
+            // a change of strategy later on, could be to send ALSO to the client all the client state records as removal if there are not present in the queue. but this could have side effect...
             clientStates = {};
         }
         const recordsToProcess = readQueue();
@@ -108,44 +119,47 @@ function Subscription(user, subscriptionId, publication, params) {
             return;
         }
 
-    // logSub(thisSub, 'Emitting ' + (recordsToProcess.length > 1 ? recordsToProcess.length + ' records' : '1 record') + (isAllRecords ? ' (all)' : ''));
+        // logSub(thisSub, 'Emitting ' + (recordsToProcess.length > 1 ? recordsToProcess.length + ' records' : '1 record') + (isAllRecords ? ' (all)' : ''));
 
         thisSub.timestamp = getMaxTimestamp(thisSub.timestamp, recordsToProcess);
 
-        const notificationObj = {name: thisSub.publication.name, subscriptionId: thisSub.id, records: recordsToProcess, params: thisSub.params, diff: !isAllRecords};
+        const notificationObj = { name: thisSub.publication.name, subscriptionId: thisSub.id, records: recordsToProcess, params: thisSub.params, diff: !isAllRecords };
         logSub(thisSub,
             'Emitting ' + (recordsToProcess.length > 1 ? recordsToProcess.length + ' records' : '1 record') + (isAllRecords ? ' (all)' : ''));
 
         thisSub.socket.emit('SYNC_NOW', thisSub.transport.disabled ? notificationObj : thisSub.transport.serialize(notificationObj), function(response) {
-      // The client acknowledged. now we are sure that the records were received.
+            // The client acknowledged. now we are sure that the records were received.
             removeFromQueue(recordsToProcess);
             addToCache(recordsToProcess);
 
             initialPushCompleted = true;
-      // if the publication is supposed to push the data only once...release subscription
+            // if the publication is supposed to push the data only once...release subscription
             if (thisSub.publication.once) {
                 release();
-        // otherwise if something was added to the queue meantime...let's process again..
+                // otherwise if something was added to the queue meantime...let's process again..
             } else if (hasDataToEmit()) {
-                flush();
+                thisSub.flush();
             }
         });
         return; // does not return a promise here on purpose (non blocking)
     }
 
-  /**
-     * Emit changes.
-     * change items contains the record and type (REMOVAL,ADD,UPDATE)
-     *
-     * Due to async nature, a notification for change might occur before the subscription has received the initial data.
-     * In this scenario, the change will be queued.
-     *
-     * @param <Array> of change items to push to the client subscription
-     */
+    /**
+       * Emit changes.
+       * change items contains the record and type (REMOVAL,ADD,UPDATE)
+       *
+       * Due to async nature, a notification for change might occur before the subscription has received the initial data.
+       * In this scenario, the change will be queued.
+       *
+       * @param {Array} notifications of objects to push to the client subscription
+       * @param {boolean} forceNotify
+       * @returns {boolean} true if object records were emitted to the subcription
+       *                    false if no object needs to be emitted because the subscription already has the data.
+       */
     function emitChanges(notifications, forceNotify) {
         let changesToEmit = false;
         const isQueueEmpty = !getQueueLength();
-        _.forEach(notifications, (notification) => {
+        for(const notification of notifications) {
             let record;
             if (notification.type === 'REMOVAL') {
                 record = buildLightRecordForRemoval(notification.record);
@@ -154,26 +168,25 @@ function Subscription(user, subscriptionId, publication, params) {
             } else {
                 record = notification.record;
             }
-
-      // const record = notification.type === 'REMOVAL' ? buildLightRecordForRemoval(notification.record) : notification.record;
-            changesToEmit = addToQueue(record) || changesToEmit;
-        });
-    // if there is more than one record currently in the queue...it means client has not gotten all the data yet. Could be due a slow or lost of connection/ async processing. but...so let's wait it finishes and avoid emitting again.
-    // the emitCache function will catch up and try to empty the queue anyway.
-        if (changesToEmit && initialPushCompleted && isQueueEmpty) {
-            flush();
+            changesToEmit = thisSub._addToQueue(record) || changesToEmit;
         }
+        // if there is more than one record currently in the queue...it means client has not gotten all the data yet. Could be due a slow or lost of connection/ async processing. but...so let's wait it finishes and avoid emitting again.
+        // the emitCache function will catch up and try to empty the queue anyway.
+        if (changesToEmit && initialPushCompleted && isQueueEmpty) {
+            thisSub.flush();
+        }
+        return changesToEmit;
     }
 
 
-  /**
-     * The record to be send for removal syncing does NOT need to contain all data
-     * Client only cares to know that it is removed.
-     *
-     * @param {*} record
-     * @returns {Object} light version of the record with removal flags
-     *
-     */
+    /**
+       * The record to be send for removal syncing does NOT need to contain all data
+       * Client only cares to know that it is removed.
+       *
+       * @param {*} record
+       * @returns {Object} light version of the record with removal flags
+       *
+       */
     function buildLightRecordForRemoval(record) {
         return {
             id: getIdValue(record.id),
@@ -185,7 +198,7 @@ function Subscription(user, subscriptionId, publication, params) {
             // clients are guaranteed to receive notification sends by server 2 at least,
             // Some might also receive the removal but it would only remove, then sync to readd due to the update
             revision: recalculateRevision(record),
-            timestamp: {remove: new Date()},
+            timestamp: { remove: new Date() },
             remove: new Date() // should remove in the zerv-ng-sync, and use the timestamp!!
         };
     }
@@ -215,33 +228,33 @@ function Subscription(user, subscriptionId, publication, params) {
         return currentRevision + revisionOffset;
     }
 
-    function addToQueue(record) {
+    function _addToQueue(record) {
         const recordId = getIdValue(record.id);
         const revisionToEmit = getRecordRevision(record);
         const clientStateVersion = clientStates[recordId];
 
         if (!_.isNil(clientStateVersion) && clientStateVersion >= revisionToEmit) {
-      // the client has already acknowledged to have this record or greater revision
-      // don't send it again
+            // the client has already acknowledged to have this record or greater revision
+            // don't send it again
             return false;
         }
 
         const queuedRecord = queue[recordId];
-    // prevent sending a removal for a record
-    // when it is not in clientStates and queue
+        // prevent sending a removal for a record
+        // when it is not in clientStates and queue
         if (_.isNil(clientStateVersion) && !queuedRecord && record.remove) {
-      // the client does not care about the record removal, it does not have it.
-      // So don't send it
+            // the client does not care about the record removal, it does not have it.
+            // So don't send it
             return false;
         }
-    // add to queue only if it is a version more recent
+        // add to queue only if it is a version more recent
         if (queuedRecord && getRecordRevision(queuedRecord) >= revisionToEmit) {
-      // a more recent record is already in the queue about to reach the client
-      // so don't send this old one
+            // a more recent record is already in the queue about to reach the client
+            // so don't send this old one
             return false;
         }
 
-        isDebug() && debugSub(thisSub, 'Adding record #' + record.id + ', revision ' + revisionToEmit + (record.remove?' for removal notif' : '') + ' to queue');
+        isDebug() && debugSub(thisSub, 'Adding record #' + record.id + ', revision ' + revisionToEmit + (record.remove ? ' for removal notif' : '') + ' to queue');
         queue[recordId] = record;
         return true;
     }
@@ -251,9 +264,9 @@ function Subscription(user, subscriptionId, publication, params) {
             const recordId = getIdValue(record.id);
             const previous = queue[recordId];
             if (!previous || getRecordRevision(previous) <= getRecordRevision(record)) {
-        // remove record fromo queue only except if there is already a new version more recent (Might just have been notified)
+                // remove record fromo queue only except if there is already a new version more recent (Might just have been notified)
                 delete queue[recordId];
-        // logSub(sub, 'Dropping queue to:'+readQueue().length);
+                // logSub(sub, 'Dropping queue to:'+readQueue().length);
             }
         });
     }
@@ -282,7 +295,7 @@ function Subscription(user, subscriptionId, publication, params) {
         if (!_.isObject(id)) {
             return id;
         }
-    // build composite key value
+        // build composite key value
         const r = _.join(_.map(id, function(value) {
             return value;
         }), '~');
@@ -290,8 +303,8 @@ function Subscription(user, subscriptionId, publication, params) {
     }
 
     function getRecordRevision(record) {
-    // what reserved field do we use as timestamp
-    // if the object contains a version, let's use it...otherwise it must provide a timestamp (that is set when inserting, updating or deleting from the db)
+        // what reserved field do we use as timestamp
+        // if the object contains a version, let's use it...otherwise it must provide a timestamp (that is set when inserting, updating or deleting from the db)
         if (typeof record.revision !== 'undefined' && record.revision !== null) {
             return record.revision;
         }
@@ -310,31 +323,31 @@ function Subscription(user, subscriptionId, publication, params) {
     }
 
     async function checkIfMatch(object, dataNotification) {
-    // When the subscription params are checked against the object notified to sync, the object must be serialized so it contains ids, no object references. Subscription params are id based.
+        // When the subscription params are checked against the object notified to sync, the object must be serialized so it contains ids, no object references. Subscription params are id based.
         const dataParams = JSON.parse(JSON.stringify(object));
-    // if additional params has a null param, the params should not be used as identityParams
-    // ex a subscription might pass some params not useful such as startDate, endDate, type... which are not useful for notification.
+        // if additional params has a null param, the params should not be used as identityParams
+        // ex a subscription might pass some params not useful such as startDate, endDate, type... which are not useful for notification.
         const identityParams = _.assign({}, this.params);
         _.forEach(this.additionalParams, function(value, p) {
             if (thisSub.additionalParams[p] === null) {
-        // the object notified does NOT need to contain this value to be identified
+                // the object notified does NOT need to contain this value to be identified
                 delete identityParams[p];
             } else {
-        // otherwise the object notified would need to contain this value to be identified
+                // otherwise the object notified would need to contain this value to be identified
                 identityParams[p] = value;
             }
         });
 
         const notificationFilter = publication.dataNotifications[dataNotification].filter;
         if (notificationFilter) {
-      // use the custom nofification filter to decide if the object
-      // should be sent over to the subscription
-      // the filter function has access to all necessary params to make the decision
-      // whether to notify or not the subscriber.
+            // use the custom nofification filter to decide if the object
+            // should be sent over to the subscription
+            // the filter function has access to all necessary params to make the decision
+            // whether to notify or not the subscriber.
             const result = await notificationFilter.call(this, object, identityParams, this.user, this.tenantId);
             if (!_.isNil(result)) {
-        // if the filter returns null, the default filter will apply to confirm if the object should
-        // be notified to the subscriber.
+                // if the filter returns null, the default filter will apply to confirm if the object should
+                // be notified to the subscriber.
                 return result;
             }
         }
@@ -350,8 +363,8 @@ function Subscription(user, subscriptionId, publication, params) {
         }
         let matching = true;
         for (const param in keyParams) {
-      // are other params matching the data notification?
-      // ex: we might have receive a notification about taskId=20 but we are only interested about taskId=3
+            // are other params matching the data notification?
+            // ex: we might have receive a notification about taskId=20 but we are only interested about taskId=3
             if (getIdInMinObjectIfAny(record, param) !== keyParams[param]) {
                 matching = false;
                 break;
@@ -360,15 +373,15 @@ function Subscription(user, subscriptionId, publication, params) {
         return matching;
     }
 
-  /**
-     * find the id value based on id property name in a record.
-     * Ex: the subscription params might be on opportunityId, but account object has no opportunityId but opportunity.id...so get the value there instead.
-     *
-     * @param record : object to investigate
-     * @param param: id name
-     *
-     * @returns id
-     */
+    /**
+       * find the id value based on id property name in a record.
+       * Ex: the subscription params might be on opportunityId, but account object has no opportunityId but opportunity.id...so get the value there instead.
+       *
+       * @param record : object to investigate
+       * @param param: id name
+       *
+       * @returns id
+       */
     function getIdInMinObjectIfAny(record, param) {
         const p = param.indexOf('Id');
         if (p !== -1) {
@@ -399,13 +412,13 @@ function Subscription(user, subscriptionId, publication, params) {
         throw new Error('RECORD_NOT_FOUND');
     }
 
-  /**
-     * release the subscription from memory...
-     * If the client were to reconnect (after a long period of network of disconnection), a new subscription would be created
-     */
+    /**
+       * release the subscription from memory...
+       * If the client were to reconnect (after a long period of network of disconnection), a new subscription would be created
+       */
     function release() {
         isDebug() && debugSub(thisSub, 'Unsubscribed.');
-    // ubound socket to this subscription if not done already (disconnect)
+        // ubound socket to this subscription if not done already (disconnect)
         if (thisSub.socket) {
             const i = thisSub.socket.subscriptions.indexOf(thisSub);
             if (i !== -1) {
@@ -437,7 +450,7 @@ function debugSub(subscription, text) {
 
 let isDebugLevel;
 function isDebug() {
-  // quick fix to improve performance. logger should have logger.canLog('DEBUG')
+    // quick fix to improve performance. logger should have logger.canLog('DEBUG')
     if (_.isNil(isDebugLevel)) {
         let l = logger.getLevel() || 'all';
         l = l.toUpperCase();

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -177,13 +177,13 @@ function Subscription(user, subscriptionId, publication, params) {
     function buildLightRecordForRemoval(record) {
         return {
             id: getIdValue(record.id),
-      // we do not need to increase the revision number from the outside for removal
-      // this cover the following issue on concurrent removal and update
-      // server 1 notifies a removal of record rev 1, which is automatically increased of value based on time in the decimal part
-      // server 2 notifies an update of the same record revision at the same time which is increased to 2
-      // Expectation:
-      // clients are guaranteed to receive notification sends by server 2 at least,
-      // Some might also receive the removal but it would only remove, then sync to readd due to the update
+            // we do not need to increase the revision number from the outside for removal
+            // this cover the following issue on concurrent removal and update
+            // server 1 notifies a removal of record rev 1, which is automatically increased of value based on time in the decimal part
+            // server 2 notifies an update of the same record revision at the same time which is increased to 2
+            // Expectation:
+            // clients are guaranteed to receive notification sends by server 2 at least,
+            // Some might also receive the removal but it would only remove, then sync to readd due to the update
             revision: recalculateRevision(record),
             timestamp: {remove: new Date()},
             remove: new Date() // should remove in the zerv-ng-sync, and use the timestamp!!
@@ -196,19 +196,22 @@ function Subscription(user, subscriptionId, publication, params) {
         });
     }
 
-  /**
-   * In order to force a record to a client which might already have it
-   * The revision must be artificially increased to minor revision.
-   * 
-   * @param {Object} record
-   * @return {Number} revision with decimal part based on timestamp
-   */
+    /**
+     * In order to force a record to a client which might already have it
+     * The revision must be artificially increased to minor revision.
+     * 
+     * @param {Object} record
+     * @return {Number} revision with decimal part based on timestamp
+     */
     function recalculateRevision(record) {
-    // make sure the base revision has no decimal
-    // so that offset can be added based on time reference.
+        // make sure the base revision has no decimal
+        // so that offset can be added based on time reference.
         const currentRevision = Math.trunc(getRecordRevision(record));
-    // decrease precision that is not needed to 10th of second
-        const revisionOffset = Math.trunc(Date.now() /100)/Math.pow(10, 11);
+        // a same record with a same revison can only be refreshed during the next 3 days
+        // Then when notifying the same record with same revision multiple times during a short instant, the probality that the revision offset
+        // is the same is extremly low even on a fast machine.
+        // This is important if subscription filters must be revevaluated quickly dunring notification.
+        const revisionOffset = (Date.now() / (1000 * 60 * 60 * 24 * 3)) % 1;
         return currentRevision + revisionOffset;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,82 @@
+'strict mode';
+
+const _ = require('lodash');
+const DEFAULT_MAX_BATCH_SIZE = 2000;
+
+const service = {
+    breath,
+    // for testing
+    DEFAULT_MAX_BATCH_SIZE,
+    _clearBreath,
+    _giveRoomForOtherAsyncFunctionsToBeAddedToEventLoop,
+    _trackBreath: _.noop
+};
+
+module.exports = service;
+
+/**
+ * Breath function prevents the publications from taking over the node process when receiving large number of notifications (1000s)
+ * Function relying on time such as timeout/interval functions would be impacted negativaly (unpredictable) and delayed for a substantial amount of time.
+ */
+let lastActivity = 0;
+let maxBatch;
+
+
+const breathQueue = [];
+async function breath() {
+    let nextBreath = _.last(breathQueue);
+    
+    if (!nextBreath) {
+        nextBreath = {
+            promise: Promise.resolve(service._trackBreath()),
+            count: 0,
+            queued: false
+        };
+        breathQueue.push(nextBreath);
+    } else if (nextBreath.count >= getMaxBatch() - 1) {
+        const previousBreath = nextBreath;
+        nextBreath = {
+            count: 0,
+            queued: true, // depends on the previous one to complete
+            promise: new Promise(async (resolve) => {
+                // when previous breath is completed, 
+                await previousBreath.promise; 
+                // time to breath again
+                service._giveRoomForOtherAsyncFunctionsToBeAddedToEventLoop(resolve);
+            })
+        };
+        breathQueue.push(nextBreath);
+    } else {
+        if (!nextBreath.queued && Date.now() > lastActivity + 2000) {
+            // no much activity (nothing in the queue), no need to count before breathing
+            // console.info('no need to breath');
+            nextBreath.count = 0;
+        } else {
+            // busy, let's count, when the maxBatch size is met, 
+            // the system will free up time for the event loop to proceed other asynchronous calls
+            nextBreath.count ++;
+        }
+    }
+    lastActivity = Date.now();
+    return nextBreath.promise;
+}
+
+function _giveRoomForOtherAsyncFunctionsToBeAddedToEventLoop(callback) {
+    // console.info('breath now');
+    setTimeout(() => {
+        breathQueue.shift();
+        callback(service._trackBreath());
+        // console.info('Done breathing');
+    }, 100);
+}
+
+function getMaxBatch() {
+    if (!maxBatch) {
+        maxBatch = Number(process.env.ZERV_BATCH_MAX || DEFAULT_MAX_BATCH_SIZE);
+    }
+    return maxBatch;
+}
+
+function _clearBreath() {
+    breathQueue.length = 0;
+}

--- a/lib/zerv-sync.js
+++ b/lib/zerv-sync.js
@@ -380,12 +380,13 @@ if (!sync) {
      * @param {uid} tenantId,
      * @param {String} dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
      * @param {array/object} record: Object/Record to notify to listening publication (must at least have an id and revision number)
-     *
+     * 
+     *  @returns {Promise<number>} number of notifications which are scheduled to be emitted to the interested subscriptions.
      * Notes:
      * TO REMOVE!!! Options: {boolean} [forceNotify=false] Notify even if there was no match with the record.
      */
     function notifyCreation(tenantId, dataNotification, object, options) {
-        notifyRecordActivity(tenantId, dataNotification, 'ADD', object, options);
+        return notifyRecordActivity(tenantId, dataNotification, 'ADD', object, options);
     }
 
   /**
@@ -396,10 +397,11 @@ if (!sync) {
      * @param {String} dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
      * @param {array/object} record: Object/Record to notify to listening publication (must at least have an id and revision number)
      *
-     *
+     * 
+     *  @returns {Promise<number>} number of notifications which are scheduled to be emitted to the interested subscriptions.
      */
     function notifyDelete(tenantId, dataNotification, object, options) {
-        notifyRecordActivity(tenantId, dataNotification, 'REMOVAL', object, options);
+        return notifyRecordActivity(tenantId, dataNotification, 'REMOVAL', object, options);
     }
 
   /**
@@ -409,10 +411,11 @@ if (!sync) {
      * @param {uid} tenantId,
      * @param {String} dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
      * @param {array/object} record: Object/Record to notify to listening publication (must at least have an id and revision number)
-     *
+     * 
+     *  @returns {Promise<number>} number of notifications which are scheduled to be emitted to the interested subscriptions.
      */
     function notifyUpdate(tenantId, dataNotification, object, options) {
-        notifyRecordActivity(tenantId, dataNotification, 'UPDATE', object, options);
+        return notifyRecordActivity(tenantId, dataNotification, 'UPDATE', object, options);
     }
 
   /**
@@ -425,10 +428,11 @@ if (!sync) {
      * @param {uid} tenantId,
      * @param {String} dataNotification:   string to define the type of object we are notifying and publications are potentially listening to.
      * @param {array/object} record: Object/Record to notify to listening publication (must at least have an id and revision number)
-     *
+     * 
+     *  @returns {Promise<number>} number of notifications which are scheduled to be emitted to the interested subscriptions.
      */
     function notifyRefresh(tenantId, dataNotification, object, options) {
-        notifyRecordActivity(tenantId, dataNotification, 'UPDATE', object, _.assign({}, options, {forceNotify: true}));
+        return notifyRecordActivity(tenantId, dataNotification, 'UPDATE', object, _.assign({}, options, {forceNotify: true}));
     }
 
   // //////////////// HELPERS //////////////////////
@@ -439,12 +443,20 @@ if (!sync) {
      *  @param {string} tenantId
      *  @param {string} dataNotification
      *  @param {String} notificationType
-     *  @param {array} records
+     *  @param {array} objects or single object
      *  @param {Object} options
+     * 
+     *  @returns {Promise<number>} number of notifications which are scheduled to be emitted to the interested subscriptions
+     * 
      */
     function notifyRecordActivity(tenantId, dataNotification, notificationType, objects, options) {
         if (!_.isArray(objects)) {
             objects = [objects];
+        }
+
+        // nothing to notify?
+        if (!objects.length) {
+            return Promise.resolve(0);
         }
 
         options = options || {};
@@ -453,16 +465,18 @@ if (!sync) {
             cluster.broadcast(tenantId, dataNotification, notificationType, objects, options);
         };
 
-        processRecordNotifications(tenantId, dataNotification, notificationType, objects, options);
+        return processRecordNotifications(tenantId, dataNotification, notificationType, objects, options);
     }
 
-    function processRecordNotifications(tenantId, dataNotification, notificationType, objects, options) {
+    async function processRecordNotifications(tenantId, dataNotification, notificationType, objects, options) {
         notifyChangeListeners(tenantId, dataNotification, notificationType, objects, options);
 
-        findPublicationsListeningToDataNotification(dataNotification)
-        .forEach(function(publication) {
-            publication.notifySubscriptions(tenantId, dataNotification, notificationType, objects, options);
-        });
+        const publications = findPublicationsListeningToDataNotification(dataNotification);
+        let objectsNotifiedTotal = 0;
+        for (const publication of publications) {
+            objectsNotifiedTotal += await publication.notifySubscriptions(tenantId, dataNotification, notificationType, objects, options);
+        }
+        return objectsNotifiedTotal;
     }
 
   /**

--- a/lib/zerv-sync.js
+++ b/lib/zerv-sync.js
@@ -36,10 +36,9 @@
  *
  */
 
-const Promise = require('promise'),
-    zlog = require('zimit-zlog'),
-    UUID = require('uuid'),
-    _ = require('lodash');
+const _ = require('lodash');
+const zlog = require('zimit-zlog');
+const UUID = require('uuid');
 
 const Publication = require('./publication');
 const Subscription = require('./subscription');
@@ -328,9 +327,7 @@ if (!sync) {
             }
         } else if (typeof dataNotification === 'string') {
             dataNotifications = {};
-            dataNotifications[dataNotification] = {
-                format: (record) => Promise.resolve(record)
-            };
+            dataNotifications[dataNotification] = {};
         } else {
       // dataNotification is an object:
       // ex: {USER_DATA:function(record) { return superUser(record)}};
@@ -343,7 +340,7 @@ if (!sync) {
                     };
                 } else {
                     dataNotifications[key] = {
-                        format: value.format || ((record) => Promise.resolve(record)),
+                        format: value.format || null,
                         filter: value.filter
                     };
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-sync",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Zerv module providing data synchronization support",
   "main": "lib/zerv-sync.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-sync",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Zerv module providing data synchronization support",
   "main": "lib/zerv-sync.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-sync",
-  "version": "1.1.14",
+  "version": "1.1.13",
   "description": "Zerv module providing data synchronization support",
   "main": "lib/zerv-sync.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zerv-sync",
-  "version": "1.1.13",
+  "version": "1.2.0",
   "description": "Zerv module providing data synchronization support",
   "main": "lib/zerv-sync.js",
   "keywords": [

--- a/spec/server-sync.spec.js
+++ b/spec/server-sync.spec.js
@@ -13,7 +13,7 @@ let userId;
 let subscription;
 let nullValue, clientGeneratedsubscription2;
 
-let magazine1, magazine1b, magazine2, magazine2Deleted, magazine2updated, magazine3, magazine3b, magazine3Deleted, magazine4;
+let magazine1V1, magazine1V2, magazine1V3, magazine2V7, magazine2DeletedV8, magazine2updatedV8, magazine3V9, magazine3V10, magazine3DeletedV11, magazine4;
 
 describe('Sync', () => {
 
@@ -21,16 +21,18 @@ describe('Sync', () => {
         nullValue = null;
         clientGeneratedsubscription2 = '#222';
 
-        magazine1 = { id: '1', name: 'iron man', revision: 0, type: 'fiction' };
-        magazine1b = { id: '1', name: 'IRONMAN', revision: 1, type: 'fiction' };
+        magazine1V1 = { id: '1', name: 'ironfix', revision: 1, type: 'fiction' };
+        magazine1V2 = { id: '1', name: 'iron man', revision: 2, type: 'fiction' };
+        magazine1V3 = { id: '1', name: 'IRONMAN', revision: 3, type: 'fiction' };
 
-        magazine2 = { id: '2', name: 'spider man', revision: 7, type: 'fiction' };
-        magazine2Deleted = { id: '2', name: 'spider man', revision: 8, type: 'fiction' };
-        magazine2updated = { id: '2', name: 'spider man', revision: 8, type: 'miscellanous' };
+        magazine2V7 = { id: '2', name: 'spider man', revision: 7, type: 'fiction' };
+        magazine2DeletedV8 = { id: '2', name: 'spider man', revision: 8, type: 'fiction' };
+        magazine2updatedV8 = { id: '2', name: 'spider man', revision: 8, type: 'miscellanous' };
 
-        magazine3 = { id: '3', name: 'Entrepreneur', revision: 9, type: 'business' };
-        magazine3b = { id: '3', name: 'The Entrepreneur', revision: 10, type: 'business' };
-        magazine3Deleted = { id: '3', name: 'Entrepreneur', revision: 11, type: 'business' };
+        magazine3V9 = { id: '3', name: 'Entrepreneur', revision: 9, type: 'business' };
+        magazine3V10 = { id: '3', name: 'The Entrepreneur', revision: 10, type: 'business' };
+        magazine3DeletedV11 = { id: '3', name: 'Entrepreneur', revision: 11, type: 'business' };
+
         magazine4 = { id: '4', name: 'Heroes', revision: 1, type: 'fiction' };
 
         tenantId = 'TID';
@@ -65,7 +67,7 @@ describe('Sync', () => {
     beforeEach(() => {
         sync.publish(
             'magazines',
-            () => Promise.resolve([magazine1, magazine2]),
+            () => Promise.resolve([magazine1V2, magazine2V7]),
             'MAGAZINE_DATA');
     });
 
@@ -164,8 +166,8 @@ describe('Sync', () => {
         it('should subscribe and receive subscription data', async () => {
             const sub = await waitForReceivingSubscribedData();
             expect(sub.records.length).toBe(2);
-            expect(sub.records[0].name).toBe(magazine1.name);
-            expect(sub.records[1].name).toBe(magazine2.name);
+            expect(sub.records[0].name).toBe(magazine1V2.name);
+            expect(sub.records[1].name).toBe(magazine2V7.name);
         });
 
         it('should subscribe and receive all data (not a diff)', async () => {
@@ -189,56 +191,56 @@ describe('Sync', () => {
         it('should receive an update', async () => {
             await waitForReceivingSubscribedData();
             // the client has the data
-            expect(subscription.getSyncedRecordVersion(magazine1.id)).toBe(0);
+            expect(subscription.getSyncedRecordVersion(magazine1V2.id)).toBe(2);
 
-            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1b);
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1V3);
       
             const sub2 = await waitForReceivingSubscribedData();
 
             expect(sub2.diff).toBe(true);
             expect(sub2.records.length).toBe(1);
-            expect(subscription.getSyncedRecordVersion(magazine1.id)).toBe(1);
+            expect(subscription.getSyncedRecordVersion(magazine1V2.id)).toBe(3);
         });
 
         it('should receive an addition',  async () => {
             await waitForReceivingSubscribedData();
             // the client does not have the data
-            expect(subscription.getSyncedRecordVersion(magazine3.id)).toBeUndefined();
+            expect(subscription.getSyncedRecordVersion(magazine3V9.id)).toBeUndefined();
             expect(socket.emit.calls.count()).toBe(1);
 
-            sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine3);
+            sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine3V9);
             const sub2 = await waitForReceivingSubscribedData();
             expect(sub2.diff).toBe(true);
             expect(sub2.records.length).toBe(1);
-            expect(subscription.getSyncedRecordVersion(magazine3.id)).toBe(9);
+            expect(subscription.getSyncedRecordVersion(magazine3V9.id)).toBe(9);
         });
 
         it('should receive a removal', async () => {
             await waitForReceivingSubscribedData();
             // the client has the data
-            expect(subscription.getSyncedRecordVersion(magazine2Deleted.id)).toBe(7);
+            expect(subscription.getSyncedRecordVersion(magazine2DeletedV8.id)).toBe(7);
 
-            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2Deleted);
+            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2DeletedV8);
             const sub2 = await waitForReceivingSubscribedData();
             expect(sub2.diff).toBe(true);
             expect(sub2.records.length).toBe(1);
-            expect(subscription.getSyncedRecordVersion(magazine2Deleted.id)).toBeUndefined();
+            expect(subscription.getSyncedRecordVersion(magazine2DeletedV8.id)).toBeUndefined();
             expect(sub2.records[0].revision>8).toBeTrue();
             expect(sub2.records[0].revision<9).toBeTrue();
         });
 
-        it('should receive a removal EVEN THOUGH the revision was not increased', async () => {
+        it('should receive an update after a removal', async () => {
             await waitForReceivingSubscribedData();
             // the client has the data
-            expect(subscription.getSyncedRecordVersion(magazine2.id)).toBe(7);
+            expect(subscription.getSyncedRecordVersion(magazine2V7.id)).toBe(7);
                 
             // server does keep track of what is on the client
-            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2);
+            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2V7);
             const sub2 = await waitForReceivingSubscribedData();
 
             expect(sub2.diff).toBe(true);
             expect(sub2.records.length).toBe(1);
-            expect(sub2.records[0].id).toBe(magazine2.id);
+            expect(sub2.records[0].id).toBe(magazine2V7.id);
             expect(sub2.records[0].revision>7).toBeTrue();
             expect(sub2.records[0].revision<8).toBeTrue();
             // if there is a consecutive update (or even concurrent), the deleted will not interfer
@@ -249,13 +251,59 @@ describe('Sync', () => {
             // Expectation:
             // clients are guaranteed to receive notification sends by server 2 at least,
             // Some might also receive the removal but it would only remove, then sync to readd due to the update
-            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine2updated);
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine2updatedV8);
             const sub3 = await waitForReceivingSubscribedData();
 
             expect(sub3.diff).toBe(true);
             expect(sub3.records.length).toBe(1);
-            expect(sub3.records[0].id).toBe(magazine2.id);
+            expect(sub3.records[0].id).toBe(magazine2V7.id);
             expect(sub3.records[0].revision).toBe(8);
+        });
+
+
+        it('should receive an update after a removal EVEN THOUGH the revision was not increased', async () => {
+            await waitForReceivingSubscribedData();
+            // the client has the data
+            expect(subscription.getSyncedRecordVersion(magazine2DeletedV8.id)).toBe(7);
+                
+            // server does keep track of what is on the client
+            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2DeletedV8);
+            await waitForReceivingSubscribedData();
+
+            // ex:
+            // 2 servers executed an operation on the same object of the same revision
+            // one notified a remove
+            // one notified an update
+            //
+            // in this case, client gets removal first then the update which would re-add the deleted record
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine2updatedV8);
+            const sub3 = await waitForReceivingSubscribedData();
+
+            expect(sub3.diff).toBe(true);
+            expect(sub3.records.length).toBe(1);
+            expect(sub3.records[0].id).toBe(magazine2V7.id);
+            expect(sub3.records[0].revision).toBe(8);
+        });
+
+        it('should receive a removal after an update EVEN THOUGH the revision was not increased', async () => {
+            await waitForReceivingSubscribedData();
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine2updatedV8);
+            await waitForReceivingSubscribedData();
+            // server does keep track of what is on the client
+            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2DeletedV8);
+
+            // ex:
+            // 2 servers executed an operation on the same object of the same revision
+            // one notified an update
+            // one notified a remove
+            //
+            // in this case, client gets update first then the removal
+            const sub3 = await waitForReceivingSubscribedData();
+            expect(sub3.diff).toBe(true);
+
+            expect(subscription.getSyncedRecordVersion(magazine2DeletedV8.id)).toBeUndefined();
+            expect(sub3.records[0].revision>8).toBeTrue();
+            expect(sub3.records[0].revision<9).toBeTrue();
         });
 
     });
@@ -281,7 +329,7 @@ describe('Sync', () => {
 
         it('should receive an update', async () => {
             await waitForReceivingSubscribedData();
-            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1b);
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1V3);
             const sub2 = await waitForReceivingSubscribedData();
             expect(sub2.records.length).toBe(1);
         });
@@ -295,42 +343,72 @@ describe('Sync', () => {
 
         it('should receive a removal', async () => {
             await waitForReceivingSubscribedData();
-            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2Deleted);
+            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine2DeletedV8);
             const sub2 = await waitForReceivingSubscribedData();
             expect(sub2.records.length).toBe(1);
         });
 
         it('should receive a removal for an update notification since the record does no longer matches the subscription', async () => {
             await waitForReceivingSubscribedData();
-            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine2updated);
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine2updatedV8);
             const sub2 = await waitForReceivingSubscribedData();
             expect(sub2.records.length).toBe(1);
         });
 
-        it('should NOT notified the addition unrelated to subscription', async () => {
+        it('should NOT notified the addition of an object unrelated to subscription', async () => {
             await waitForReceivingSubscribedData();
-            sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine3);
+            sync.notifyCreation(tenantId, 'MAGAZINE_DATA', magazine3V9);
             expect(socket.emit.calls.count()).toBe(1);
         });
 
-        it('should NOT notified the update unrelated to subscription', async () => {
+        it('should NOT notified the update of an object unrelated to subscription', async () => {
             await waitForReceivingSubscribedData();
-            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine3b);
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine3V10);
             expect(socket.emit.calls.count()).toBe(1);
         });
 
-        it('should NOT notify a revision of an object that was already emitted', async () => {
+        it('should NOT notified the removal of an object unrelated to subscription', async () => {
+            await waitForReceivingSubscribedData();
+            sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine3V10);
+            expect(socket.emit.calls.count()).toBe(1);
+        });
+
+        it('should NOT notify a revision refresh of an object unrelated to subscription', async () => {
+            await waitForReceivingSubscribedData();
+            sync.notifyRefresh(tenantId, 'MAGAZINE_DATA', magazine3V10);
+            expect(socket.emit.calls.count()).toBe(1);
+        });
+
+        it('should NOT notify a revision update of an object that was already emitted', async () => {
             await waitForReceivingSubscribedData();
             // Let's notify what was already sent during subscription initialization
-            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1);
+            sync.notifyUpdate(tenantId, 'MAGAZINE_DATA', magazine1V2);
             const hasRecordsToEmit = await deferredEmitChanges.promise;
             expect(hasRecordsToEmit).toBeFalse();
             expect(socket.emit.calls.count()).toBe(1);
         });
 
-        it('should NOT notified the removal unrelated to subscription', async () => {
+        it('should NOT notify the removal unrelated to subscription', async () => {
             await waitForReceivingSubscribedData();
-            await sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine3Deleted);
+            await sync.notifyDelete(tenantId, 'MAGAZINE_DATA', magazine3DeletedV11);
+            expect(socket.emit.calls.count()).toBe(1);
+        });
+
+        it('should NOT notify a revision refresh of an object that was already emitted', async () => {
+            await waitForReceivingSubscribedData();
+            // Let's notify what was already sent during subscription initialization
+            sync.notifyRefresh(tenantId, 'MAGAZINE_DATA', magazine1V2);
+            const hasRecordsToEmit = await deferredEmitChanges.promise;
+            expect(hasRecordsToEmit).toBeFalse();
+            expect(socket.emit.calls.count()).toBe(1);
+        });
+
+        it('should NOT notify a revision refresh of an object that has an older version', async () => {
+            await waitForReceivingSubscribedData();
+            // Let's notify what was already sent during subscription initialization
+            sync.notifyRefresh(tenantId, 'MAGAZINE_DATA', magazine1V1);
+            const hasRecordsToEmit = await deferredEmitChanges.promise;
+            expect(hasRecordsToEmit).toBeFalse();
             expect(socket.emit.calls.count()).toBe(1);
         });
 
@@ -372,13 +450,13 @@ describe('Sync', () => {
             it('should match the object with the custom filter and subscription params so that it can be sent to the subscription', async () => {
                 subscription = sync.subscribe(handler.user, handler.socket, nullValue, 'filteredMagazines', { type: 'fiction' });
                 // magazin1 does have 'man' in its name and is a fiction book
-                expect(await subscription.checkIfMatch(magazine1, 'MAGAZINE_DATA')).toEqual(true);
+                expect(await subscription.checkIfMatch(magazine1V2, 'MAGAZINE_DATA')).toEqual(true);
             });
 
             it('should match the object with the custom filter; however object does not match the subscription params so that it can NOT be sent to the subscription', async () => {
                 subscription = sync.subscribe(handler.user, handler.socket, nullValue, 'filteredMagazines', { type: 'business' });
                 // magazin1 does have 'man' in its name but is not a business book
-                expect(await subscription.checkIfMatch(magazine1, 'MAGAZINE_DATA')).toEqual(false);
+                expect(await subscription.checkIfMatch(magazine1V2, 'MAGAZINE_DATA')).toEqual(false);
             });
 
             it('should NOT match the object with the custom filter. Though object matches the subscription params, it can NOT be sent to the subscription', async () => {
@@ -390,7 +468,7 @@ describe('Sync', () => {
             it('should NOT match the object with the custom filter. Whether object matches the subscription params, it will not be sent to the subscription', async () => {
                 subscription = sync.subscribe(handler.user, handler.socket, nullValue, 'filteredMagazines', { type: 'fiction' });
                 // magazin3 does not have 'man' in its name
-                expect(await subscription.checkIfMatch(magazine3, 'MAGAZINE_DATA')).toEqual(false);
+                expect(await subscription.checkIfMatch(magazine3V9, 'MAGAZINE_DATA')).toEqual(false);
             });
 
         });
@@ -418,7 +496,7 @@ describe('Sync', () => {
 
             it('should match the object with the custom filter without considering the subscription params; Object would then be sent to the subscription', async () => {
                 subscription = sync.subscribe(handler.user, handler.socket, nullValue, 'filteredMagazines', { type: 'business' });
-                expect(await subscription.checkIfMatch(magazine1, 'MAGAZINE_DATA')).toEqual(true);
+                expect(await subscription.checkIfMatch(magazine1V2, 'MAGAZINE_DATA')).toEqual(true);
             });
 
         });

--- a/spec/utils.spec.js
+++ b/spec/utils.spec.js
@@ -1,0 +1,78 @@
+'strict mode';
+
+const utils= require('../lib/utils');
+
+describe('utils', () => {
+
+    let breath;
+    let maxBatch;
+    let breaths;
+    let breathCount;
+
+    beforeEach(() => {
+        maxBatch = process.env.ZERV_BATCH_MAX = 20;
+        breaths = [];
+        breathCount = 0;
+        spyOn(utils, '_trackBreath').and.callFake(() => breathCount++);
+
+    });
+
+    it('should NOT need to breath when called a few times', async () => {
+        for(let n = 0; n < maxBatch; n++) {
+            breaths.push(utils.breath());
+        } 
+        for(let n = 0; n < breaths.length; n++) {
+            expect(await breaths[n]).toBe(0);
+        }
+    });
+
+    it('should breath when called many times', async () => {
+        for(let n = 0; n < maxBatch; n++) {
+            utils.breath();
+        } 
+        // this time it should breath
+        breath = await utils.breath();
+        expect(breath).toBe(1);  
+    });
+
+    it('should breath each time batch size is reached', async () => {
+        for(let n = 0; n < maxBatch * 3 + 1; n++) {
+            breaths.push(utils.breath());
+        } 
+        for(let n = 0; n < breaths.length; n++) {
+            if (n< maxBatch) {
+                expect(await breaths[n]).toBe(0);
+            } else  if (n< maxBatch * 2) {
+                expect(await breaths[n]).toBe(1);
+            } else  if (n< maxBatch * 3) {
+                expect(await breaths[n]).toBe(2);
+            } else {
+                expect(await breaths[n]).toBe(3);
+            }
+        }
+    });
+
+    xit('should NOT breath when last activity was sometime ago', async () => {
+        jasmine.clock().install();
+        try {
+            for(let n = 0; n < (Number(maxBatch)) + 10; n++) {
+                breaths.push(utils.breath());
+            }   
+            jasmine.clock().tick(1000);
+
+            const last = utils.breath();
+            jasmine.clock().tick(3000);
+
+            expect(await last).toBeNull();
+        } finally {
+            jasmine.clock().uninstall();
+        }
+        
+    });
+
+    afterEach(() => {
+        utils._clearBreath();
+    });
+});
+
+


### PR DESCRIPTION
Jira Task: https://zimitio.atlassian.net/browse/ZWEB-5800

**Steps to Reproduce**

- It is a performance fix on publication of object removals and notifications of arrays.
- Most work was to clean up the old unit tests and add more coverage.
- the notify functions (notifyCreation, notifyDelete, notifyUpdate) are now async. When they complete, it means the data is being sent by the socket. 

Run:
`npm test`

**Performance Considerations**
This is a performance improvement.
There was an issue with the publication filter which would send removal of objects to subscriptions that did not have the object in their cache. Causing additional network traffic even though it was a few bytes. The client subscription would disregard the data received over the network anyway.

**Sections of the Application Affected**
Look up application pr to QA.